### PR TITLE
Add Supabase magic link auth endpoints

### DIFF
--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -1,0 +1,76 @@
+import { AuthApiError } from "@supabase/supabase-js";
+import { NextResponse } from "next/server";
+
+import { getSupabaseAdminClient } from "@/lib/supabase-client";
+import { consumeMagicLinkToken } from "@/lib/token-store";
+
+const DEFAULT_REDIRECT_PATH = "/";
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const token = url.searchParams.get("token");
+
+  if (!token) {
+    return NextResponse.json(
+      { error: "Missing token" },
+      {
+        status: 400,
+      },
+    );
+  }
+
+  const consumed = consumeMagicLinkToken(token);
+
+  if (!consumed) {
+    return NextResponse.json(
+      { error: "Invalid or expired token" },
+      {
+        status: 400,
+      },
+    );
+  }
+
+  let supabaseClient;
+
+  try {
+    supabaseClient = getSupabaseAdminClient();
+  } catch (error) {
+    console.error("Supabase client misconfiguration", error);
+    return NextResponse.json(
+      { error: "Supabase client is not configured" },
+      {
+        status: 500,
+      },
+    );
+  }
+
+  try {
+    const { error } = await supabaseClient.auth.admin.createUser({
+      email: consumed.email,
+      email_confirm: true,
+    });
+
+    if (error && !(error instanceof AuthApiError && error.status === 422)) {
+      throw error;
+    }
+  } catch (error) {
+    console.error("Failed to finalize Supabase user", error);
+    return NextResponse.json(
+      { error: "Unable to finalize login" },
+      {
+        status: 500,
+      },
+    );
+  }
+
+  return NextResponse.json(
+    {
+      message: "Magic link verified",
+      email: consumed.email,
+      redirectTo: consumed.redirectTo ?? DEFAULT_REDIRECT_PATH,
+    },
+    {
+      status: 200,
+    },
+  );
+}

--- a/app/api/auth/magiclink/route.ts
+++ b/app/api/auth/magiclink/route.ts
@@ -1,0 +1,158 @@
+import { randomBytes } from "node:crypto";
+
+import { AuthApiError } from "@supabase/supabase-js";
+import { NextResponse } from "next/server";
+
+import { getSupabaseAdminClient } from "@/lib/supabase-client";
+import { MAGIC_LINK_TOKEN_TTL_MS, storeMagicLinkToken } from "@/lib/token-store";
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const SECONDS_IN_MS = 1000;
+
+function normalizeEmail(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function sanitizeRedirect(value: unknown) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.startsWith("//") || trimmed.startsWith("http")) {
+    return null;
+  }
+
+  if (!trimmed.startsWith("/")) {
+    return null;
+  }
+
+  return trimmed;
+}
+
+function buildMagicLink(originUrl: string, token: string, redirectTo: string | null) {
+  const magicLinkUrl = new URL("/api/auth/callback", originUrl);
+  magicLinkUrl.searchParams.set("token", token);
+
+  if (redirectTo) {
+    magicLinkUrl.searchParams.set("redirect_to", redirectTo);
+  }
+
+  return magicLinkUrl.toString();
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      {
+        status: 400,
+      },
+    );
+  }
+
+  if (typeof body !== "object" || body === null) {
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      {
+        status: 400,
+      },
+    );
+  }
+
+  const { email: rawEmail } = body as { email?: unknown };
+
+  if (typeof rawEmail !== "string") {
+    return NextResponse.json(
+      { error: "Email is required" },
+      {
+        status: 400,
+      },
+    );
+  }
+
+  const email = normalizeEmail(rawEmail);
+
+  if (!EMAIL_REGEX.test(email)) {
+    return NextResponse.json(
+      { error: "A valid email address is required" },
+      {
+        status: 400,
+      },
+    );
+  }
+
+  const redirectTo = sanitizeRedirect(
+    (body as { redirectTo?: unknown; redirect_to?: unknown }).redirectTo ??
+      (body as { redirectTo?: unknown; redirect_to?: unknown }).redirect_to,
+  );
+
+  let supabaseClient;
+
+  try {
+    supabaseClient = getSupabaseAdminClient();
+  } catch (error) {
+    console.error("Supabase client misconfiguration", error);
+    return NextResponse.json(
+      { error: "Supabase client is not configured" },
+      {
+        status: 500,
+      },
+    );
+  }
+
+  let supabaseUserId: string | null = null;
+
+  try {
+    const { data, error } = await supabaseClient.auth.admin.createUser({
+      email,
+      email_confirm: true,
+    });
+
+    if (error) {
+      if (error instanceof AuthApiError && error.status === 422) {
+        supabaseUserId = null;
+      } else {
+        throw error;
+      }
+    } else {
+      supabaseUserId = data.user?.id ?? null;
+    }
+  } catch (error) {
+    if (error instanceof AuthApiError && error.status === 422) {
+      // user already exists - nothing else to do
+    } else {
+      console.error("Failed to ensure Supabase user", error);
+      return NextResponse.json(
+        { error: "Unable to process magic link request" },
+        {
+          status: 500,
+        },
+      );
+    }
+  }
+
+  const token = randomBytes(32).toString("hex");
+  storeMagicLinkToken(token, { email, redirectTo });
+
+  const originUrl = new URL(request.url).origin;
+  const magicLink = buildMagicLink(originUrl, token, redirectTo);
+
+  return NextResponse.json(
+    {
+      email,
+      magicLink,
+      expiresIn: Math.floor(MAGIC_LINK_TOKEN_TTL_MS / SECONDS_IN_MS),
+      redirectTo,
+      userId: supabaseUserId,
+    },
+    {
+      status: 201,
+    },
+  );
+}

--- a/lib/supabase-client.ts
+++ b/lib/supabase-client.ts
@@ -1,0 +1,32 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+const globalForSupabase = globalThis as unknown as {
+  __supabaseAdminClient?: SupabaseClient;
+};
+
+function ensureConfig(name: string, value: string | undefined) {
+  if (!value) {
+    throw new Error(`Missing required Supabase environment variable: ${name}`);
+  }
+
+  return value;
+}
+
+export function getSupabaseAdminClient() {
+  const supabaseUrl = ensureConfig("SUPABASE_URL", process.env.SUPABASE_URL);
+  const supabaseServiceRoleKey = ensureConfig(
+    "SUPABASE_SERVICE_ROLE_KEY",
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+  );
+
+  if (!globalForSupabase.__supabaseAdminClient) {
+    globalForSupabase.__supabaseAdminClient = createClient(supabaseUrl, supabaseServiceRoleKey, {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+      },
+    });
+  }
+
+  return globalForSupabase.__supabaseAdminClient;
+}

--- a/lib/token-store.ts
+++ b/lib/token-store.ts
@@ -1,0 +1,79 @@
+import { createHash } from "node:crypto";
+
+export const MAGIC_LINK_TOKEN_TTL_MS = 15 * 60 * 1000;
+
+type MagicLinkMetadata = {
+  email: string;
+  redirectTo: string | null;
+  expiresAt: number;
+};
+
+type MagicLinkTokenStore = Map<string, MagicLinkMetadata>;
+
+const globalForTokens = globalThis as unknown as {
+  __magicLinkTokenStore?: MagicLinkTokenStore;
+};
+
+const tokenStore: MagicLinkTokenStore =
+  globalForTokens.__magicLinkTokenStore ?? new Map<string, MagicLinkMetadata>();
+
+if (!globalForTokens.__magicLinkTokenStore) {
+  globalForTokens.__magicLinkTokenStore = tokenStore;
+}
+
+function hashToken(token: string) {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+function pruneExpiredTokens(now = Date.now()) {
+  for (const [key, metadata] of tokenStore) {
+    if (metadata.expiresAt <= now) {
+      tokenStore.delete(key);
+    }
+  }
+}
+
+export function storeMagicLinkToken(
+  token: string,
+  { email, redirectTo }: { email: string; redirectTo?: string | null },
+  ttlMs = MAGIC_LINK_TOKEN_TTL_MS,
+) {
+  pruneExpiredTokens();
+
+  const hashedToken = hashToken(token);
+
+  tokenStore.set(hashedToken, {
+    email,
+    redirectTo: redirectTo ?? null,
+    expiresAt: Date.now() + ttlMs,
+  });
+
+  return hashedToken;
+}
+
+export type ConsumedMagicLinkToken = {
+  email: string;
+  redirectTo?: string;
+};
+
+export function consumeMagicLinkToken(token: string): ConsumedMagicLinkToken | null {
+  pruneExpiredTokens();
+
+  const hashedToken = hashToken(token);
+  const metadata = tokenStore.get(hashedToken);
+
+  if (!metadata) {
+    return null;
+  }
+
+  tokenStore.delete(hashedToken);
+
+  if (metadata.expiresAt <= Date.now()) {
+    return null;
+  }
+
+  return {
+    email: metadata.email,
+    redirectTo: metadata.redirectTo ?? undefined,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "codexstardm",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.57.4",
         "@tanstack/react-query": "^5.87.4",
         "next": "15.5.3",
         "next-pwa": "^5.6.0",
@@ -2546,6 +2547,102 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.6.tgz",
+      "integrity": "sha512-bhjZ7rmxAibjgmzTmQBxJU6ZIBCCJTc3Uwgvdi4FewueUTAGO5hxZT1Sj6tiD+0dSXf9XI87BDdJrg12z8Uaew==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@supabase/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.1.tgz",
+      "integrity": "sha512-QWg3HV6Db2J81VQx0PqLq0JDBn4Q8B1FYn1kYcbla8+d5WDmTdwwMr+EJAxNOSs9W4mhKMv+EYCpCrTFlTj4VQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.57.4",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.57.4.tgz",
+      "integrity": "sha512-LcbTzFhHYdwfQ7TRPfol0z04rLEyHabpGYANME6wkQ/kLtKNmI+Vy+WEM8HxeOZAtByUFxoUTTLwhXmrh+CcVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.6",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.21.4",
+        "@supabase/realtime-js": "2.15.5",
+        "@supabase/storage-js": "2.12.1"
+      }
+    },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -2967,6 +3064,12 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.1.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
@@ -3001,6 +3104,15 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.44.0",
@@ -9915,6 +10027,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yallist": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.57.4",
     "@tanstack/react-query": "^5.87.4",
     "next": "15.5.3",
     "next-pwa": "^5.6.0",


### PR DESCRIPTION
## Summary
- install and configure the Supabase JavaScript client for server-side use
- add an in-memory magic-link token store that hashes tokens and expires them after 15 minutes
- implement `/api/auth/magiclink` and `/api/auth/callback` routes that issue and consume tokens while coordinating with Supabase

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8fe7457a88329b87c4dc34fa4d659