### PR TITLE
Add coupon and wallet API workflows

### DIFF
--- a/app/api/coupons/[id]/claim/route.ts
+++ b/app/api/coupons/[id]/claim/route.ts
@@ -1,0 +1,197 @@
+import { NextResponse } from "next/server";
+
+import { getSupabaseAdminClient } from "@/lib/supabase-client";
+import { ensureCouponState, transitionWallet } from "@/lib/wallet-service";
+
+type ClaimRequestBody = {
+  userId?: string;
+  walletId?: string;
+};
+
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  const couponId = params.id;
+
+  if (!couponId) {
+    return NextResponse.json(
+      { error: "Coupon id is required" },
+      { status: 400 },
+    );
+  }
+
+  let body: ClaimRequestBody;
+
+  try {
+    body = await request.json();
+  } catch (error) {
+    console.error("Failed to parse claim payload", error);
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 },
+    );
+  }
+
+  const { userId, walletId } = body ?? {};
+
+  if (!userId || !walletId) {
+    return NextResponse.json(
+      { error: "userId and walletId are required" },
+      { status: 400 },
+    );
+  }
+
+  const supabase = getSupabaseAdminClient();
+
+  const { data: coupon, error: couponError } = await supabase
+    .from("coupons")
+    .select(
+      "id, code, name, description, discount_type, discount_value, max_redemptions, redeemed_count, start_at, end_at, is_active, metadata",
+    )
+    .eq("id", couponId)
+    .maybeSingle();
+
+  if (couponError) {
+    console.error("Failed to load coupon", couponError);
+    return NextResponse.json(
+      { error: "Unable to claim coupon" },
+      { status: 500 },
+    );
+  }
+
+  if (!coupon) {
+    return NextResponse.json(
+      { error: "Coupon not found" },
+      { status: 404 },
+    );
+  }
+
+  const now = new Date();
+
+  if (!coupon.is_active) {
+    return NextResponse.json(
+      { error: "Coupon is not active" },
+      { status: 409 },
+    );
+  }
+
+  if (coupon.start_at && new Date(coupon.start_at) > now) {
+    return NextResponse.json(
+      { error: "Coupon is not yet available" },
+      { status: 409 },
+    );
+  }
+
+  if (coupon.end_at && new Date(coupon.end_at) < now) {
+    return NextResponse.json(
+      { error: "Coupon has expired" },
+      { status: 409 },
+    );
+  }
+
+  if (
+    coupon.max_redemptions !== null &&
+    coupon.redeemed_count >= coupon.max_redemptions
+  ) {
+    return NextResponse.json(
+      { error: "Coupon redemption limit reached" },
+      { status: 409 },
+    );
+  }
+
+  const { data: wallet, error: walletError } = await supabase
+    .from("wallets")
+    .select("id, user_id, status, metadata")
+    .eq("id", walletId)
+    .maybeSingle();
+
+  if (walletError) {
+    console.error("Failed to load wallet", walletError);
+    return NextResponse.json(
+      { error: "Unable to process wallet" },
+      { status: 500 },
+    );
+  }
+
+  if (!wallet) {
+    return NextResponse.json(
+      { error: "Wallet not found" },
+      { status: 404 },
+    );
+  }
+
+  if (wallet.user_id !== userId) {
+    return NextResponse.json(
+      { error: "Wallet does not belong to user" },
+      { status: 403 },
+    );
+  }
+
+  const nowIso = now.toISOString();
+
+  const { error: expireError } = await supabase
+    .from("qr_tokens")
+    .update({ expires_at: nowIso })
+    .eq("wallet_id", walletId)
+    .is("redeemed_at", null)
+    .gt("expires_at", nowIso);
+
+  if (expireError) {
+    console.error("Failed to invalidate existing QR tokens", expireError);
+  }
+
+  const updatedWallet = await transitionWallet({
+    client: supabase,
+    wallet,
+    walletId,
+    nextStatus: "claimed",
+    event: {
+      type: "coupon.claimed",
+      message: `Coupon ${coupon.code} claimed`,
+      at: nowIso,
+      details: {
+        couponId: coupon.id,
+        userId,
+      },
+    },
+    mutateMetadata: (metadata) => {
+      const nextMetadata = { ...metadata };
+      const { couponState } = ensureCouponState(nextMetadata);
+
+      couponState.couponId = coupon.id;
+      couponState.couponCode = coupon.code;
+      couponState.status = "claimed";
+      couponState.claimedAt = nowIso;
+      couponState.lastUpdatedAt = nowIso;
+      couponState.qrTokenId = null;
+      couponState.qrTokenExpiresAt = null;
+      couponState.redeemedAt = null;
+
+      nextMetadata.couponState = couponState;
+      return nextMetadata;
+    },
+  });
+
+  return NextResponse.json({
+    message: "Coupon claimed",
+    coupon: {
+      id: coupon.id,
+      code: coupon.code,
+      name: coupon.name,
+      description: coupon.description,
+      discountType: coupon.discount_type,
+      discountValue: coupon.discount_value,
+      startAt: coupon.start_at,
+      endAt: coupon.end_at,
+      metadata: coupon.metadata,
+      maxRedemptions: coupon.max_redemptions,
+      redeemedCount: coupon.redeemed_count,
+    },
+    wallet: {
+      id: updatedWallet.id,
+      status: updatedWallet.status,
+      metadata: updatedWallet.metadata,
+    },
+  });
+}

--- a/app/api/coupons/route.ts
+++ b/app/api/coupons/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server";
+
+import { getSupabaseAdminClient } from "@/lib/supabase-client";
+
+type CouponRow = {
+  id: string;
+  code: string;
+  name: string | null;
+  description: string | null;
+  discount_type: string;
+  discount_value: number;
+  max_redemptions: number | null;
+  redeemed_count: number;
+  start_at: string | null;
+  end_at: string | null;
+  is_active: boolean;
+  metadata: Record<string, unknown> | null;
+};
+
+type CouponPayload = {
+  id: string;
+  code: string;
+  name: string | null;
+  description: string | null;
+  discountType: string;
+  discountValue: number;
+  startAt: string | null;
+  endAt: string | null;
+  metadata: Record<string, unknown> | null;
+  redeemedCount: number;
+  maxRedemptions: number | null;
+};
+
+function isClaimable(coupon: CouponRow, now: Date) {
+  if (!coupon.is_active) {
+    return false;
+  }
+
+  if (coupon.start_at && new Date(coupon.start_at) > now) {
+    return false;
+  }
+
+  if (coupon.end_at && new Date(coupon.end_at) < now) {
+    return false;
+  }
+
+  if (
+    coupon.max_redemptions !== null &&
+    coupon.redeemed_count >= coupon.max_redemptions
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+export async function GET() {
+  const supabase = getSupabaseAdminClient();
+
+  const { data, error } = await supabase
+    .from("coupons")
+    .select(
+      "id, code, name, description, discount_type, discount_value, max_redemptions, redeemed_count, start_at, end_at, is_active, metadata",
+    );
+
+  if (error) {
+    console.error("Failed to fetch coupons", error);
+    return NextResponse.json(
+      { error: "Unable to load coupons" },
+      { status: 500 },
+    );
+  }
+
+  const now = new Date();
+  const coupons: CouponPayload[] = (data ?? [])
+    .filter((coupon) => isClaimable(coupon as CouponRow, now))
+    .map((coupon) => ({
+      id: coupon.id,
+      code: coupon.code,
+      name: coupon.name,
+      description: coupon.description,
+      discountType: coupon.discount_type,
+      discountValue: coupon.discount_value,
+      startAt: coupon.start_at,
+      endAt: coupon.end_at,
+      metadata: coupon.metadata,
+      redeemedCount: coupon.redeemed_count,
+      maxRedemptions: coupon.max_redemptions,
+    }));
+
+  return NextResponse.json({ coupons });
+}

--- a/app/api/wallet/[walletId]/qr/route.ts
+++ b/app/api/wallet/[walletId]/qr/route.ts
@@ -1,0 +1,247 @@
+import { NextResponse } from "next/server";
+
+import { getSupabaseAdminClient } from "@/lib/supabase-client";
+import { QR_TOKEN_TTL_SECONDS, generateQrTokenValue, hashQrToken } from "@/lib/qr-token";
+import { ensureCouponState, transitionWallet } from "@/lib/wallet-service";
+
+type GenerateQrRequestBody = {
+  userId?: string;
+  couponId?: string | null;
+};
+
+function extractCouponIdFromMetadata(metadata: unknown): string | null {
+  if (!metadata || typeof metadata !== "object") {
+    return null;
+  }
+
+  const couponState = (metadata as Record<string, unknown>).couponState;
+
+  if (!couponState || typeof couponState !== "object") {
+    return null;
+  }
+
+  const candidate = (couponState as Record<string, unknown>).couponId;
+  return typeof candidate === "string" ? candidate : null;
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: { walletId: string } },
+) {
+  const walletId = params.walletId;
+
+  if (!walletId) {
+    return NextResponse.json(
+      { error: "walletId is required" },
+      { status: 400 },
+    );
+  }
+
+  let body: GenerateQrRequestBody;
+
+  try {
+    body = await request.json();
+  } catch (error) {
+    console.error("Failed to parse wallet QR payload", error);
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 },
+    );
+  }
+
+  const { userId, couponId: providedCouponId } = body ?? {};
+
+  if (!userId) {
+    return NextResponse.json(
+      { error: "userId is required" },
+      { status: 400 },
+    );
+  }
+
+  const supabase = getSupabaseAdminClient();
+
+  const { data: wallet, error: walletError } = await supabase
+    .from("wallets")
+    .select("id, user_id, status, metadata")
+    .eq("id", walletId)
+    .maybeSingle();
+
+  if (walletError) {
+    console.error("Failed to load wallet", walletError);
+    return NextResponse.json(
+      { error: "Unable to load wallet" },
+      { status: 500 },
+    );
+  }
+
+  if (!wallet) {
+    return NextResponse.json(
+      { error: "Wallet not found" },
+      { status: 404 },
+    );
+  }
+
+  if (wallet.user_id !== userId) {
+    return NextResponse.json(
+      { error: "Wallet does not belong to user" },
+      { status: 403 },
+    );
+  }
+
+  const targetCouponId =
+    (typeof providedCouponId === "string" && providedCouponId) ||
+    extractCouponIdFromMetadata(wallet.metadata) ||
+    null;
+
+  if (!targetCouponId) {
+    return NextResponse.json(
+      { error: "Coupon id is required to generate a QR token" },
+      { status: 400 },
+    );
+  }
+
+  const { data: coupon, error: couponError } = await supabase
+    .from("coupons")
+    .select(
+      "id, code, name, discount_type, discount_value, max_redemptions, redeemed_count, start_at, end_at, is_active",
+    )
+    .eq("id", targetCouponId)
+    .maybeSingle();
+
+  if (couponError) {
+    console.error("Failed to load coupon", couponError);
+    return NextResponse.json(
+      { error: "Unable to prepare QR token" },
+      { status: 500 },
+    );
+  }
+
+  if (!coupon) {
+    return NextResponse.json(
+      { error: "Coupon not found" },
+      { status: 404 },
+    );
+  }
+
+  const now = new Date();
+
+  if (!coupon.is_active) {
+    return NextResponse.json(
+      { error: "Coupon is not active" },
+      { status: 409 },
+    );
+  }
+
+  if (coupon.start_at && new Date(coupon.start_at) > now) {
+    return NextResponse.json(
+      { error: "Coupon is not yet available" },
+      { status: 409 },
+    );
+  }
+
+  if (coupon.end_at && new Date(coupon.end_at) < now) {
+    return NextResponse.json(
+      { error: "Coupon has expired" },
+      { status: 409 },
+    );
+  }
+
+  if (
+    coupon.max_redemptions !== null &&
+    coupon.redeemed_count >= coupon.max_redemptions
+  ) {
+    return NextResponse.json(
+      { error: "Coupon redemption limit reached" },
+      { status: 409 },
+    );
+  }
+
+  const nowIso = now.toISOString();
+
+  const { error: invalidateError } = await supabase
+    .from("qr_tokens")
+    .update({ expires_at: nowIso })
+    .eq("wallet_id", walletId)
+    .is("redeemed_at", null)
+    .gt("expires_at", nowIso);
+
+  if (invalidateError) {
+    console.error("Failed to expire prior QR tokens", invalidateError);
+  }
+
+  const expiresAt = new Date(now.getTime() + QR_TOKEN_TTL_SECONDS * 1000);
+  const expiresAtIso = expiresAt.toISOString();
+  const rawToken = generateQrTokenValue();
+  const hashedToken = hashQrToken(rawToken);
+
+  const { data: insertedToken, error: insertError } = await supabase
+    .from("qr_tokens")
+    .insert({
+      user_id: wallet.user_id,
+      wallet_id: walletId,
+      coupon_id: coupon.id,
+      token: hashedToken,
+      expires_at: expiresAtIso,
+      is_single_use: true,
+      metadata: {
+        scope: "wallet.qr",
+        couponCode: coupon.code,
+      },
+    })
+    .select("id, expires_at")
+    .single();
+
+  if (insertError) {
+    console.error("Failed to create QR token", insertError);
+    return NextResponse.json(
+      { error: "Unable to create QR token" },
+      { status: 500 },
+    );
+  }
+
+  const updatedWallet = await transitionWallet({
+    client: supabase,
+    wallet,
+    walletId,
+    nextStatus: "claimed",
+    event: {
+      type: "wallet.qr_created",
+      message: `QR token issued for coupon ${coupon.code}`,
+      at: nowIso,
+      details: {
+        couponId: coupon.id,
+        qrTokenId: insertedToken.id,
+        expiresAt: expiresAtIso,
+      },
+    },
+    mutateMetadata: (metadata) => {
+      const nextMetadata = { ...metadata };
+      const { couponState } = ensureCouponState(nextMetadata);
+
+      couponState.couponId = coupon.id;
+      couponState.couponCode = coupon.code;
+      couponState.status = "claimed";
+      couponState.claimedAt = couponState.claimedAt ?? nowIso;
+      couponState.lastUpdatedAt = nowIso;
+      couponState.qrTokenId = insertedToken.id;
+      couponState.qrTokenExpiresAt = expiresAtIso;
+      couponState.redeemedAt = null;
+
+      nextMetadata.couponState = couponState;
+      return nextMetadata;
+    },
+  });
+
+  return NextResponse.json(
+    {
+      token: rawToken,
+      expiresAt: insertedToken.expires_at,
+      wallet: {
+        id: updatedWallet.id,
+        status: updatedWallet.status,
+        metadata: updatedWallet.metadata,
+      },
+    },
+    { status: 201 },
+  );
+}

--- a/app/api/wallet/[walletId]/redeem/route.ts
+++ b/app/api/wallet/[walletId]/redeem/route.ts
@@ -1,0 +1,371 @@
+import { NextResponse } from "next/server";
+
+import { getSupabaseAdminClient } from "@/lib/supabase-client";
+import { hashQrToken } from "@/lib/qr-token";
+import { ensureCouponState, transitionWallet } from "@/lib/wallet-service";
+
+type RedeemRequestBody = {
+  token?: string;
+};
+
+function extractCouponCodeFromMetadata(metadata: unknown) {
+  if (!metadata || typeof metadata !== "object") {
+    return null;
+  }
+
+  const candidate = (metadata as Record<string, unknown>).couponCode;
+  return typeof candidate === "string" ? candidate : null;
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: { walletId: string } },
+) {
+  const walletId = params.walletId;
+
+  if (!walletId) {
+    return NextResponse.json(
+      { error: "walletId is required" },
+      { status: 400 },
+    );
+  }
+
+  let body: RedeemRequestBody;
+
+  try {
+    body = await request.json();
+  } catch (error) {
+    console.error("Failed to parse redeem payload", error);
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 },
+    );
+  }
+
+  const token = body?.token;
+
+  if (!token || typeof token !== "string") {
+    return NextResponse.json(
+      { error: "token is required" },
+      { status: 400 },
+    );
+  }
+
+  const supabase = getSupabaseAdminClient();
+
+  const { data: wallet, error: walletError } = await supabase
+    .from("wallets")
+    .select("id, user_id, status, metadata")
+    .eq("id", walletId)
+    .maybeSingle();
+
+  if (walletError) {
+    console.error("Failed to load wallet", walletError);
+    return NextResponse.json(
+      { error: "Unable to load wallet" },
+      { status: 500 },
+    );
+  }
+
+  if (!wallet) {
+    return NextResponse.json(
+      { error: "Wallet not found" },
+      { status: 404 },
+    );
+  }
+
+  const hashedToken = hashQrToken(token);
+
+  const { data: qrToken, error: qrError } = await supabase
+    .from("qr_tokens")
+    .select(
+      "id, user_id, wallet_id, coupon_id, expires_at, redeemed_at, is_single_use, metadata",
+    )
+    .eq("token", hashedToken)
+    .eq("wallet_id", walletId)
+    .maybeSingle();
+
+  if (qrError) {
+    console.error("Failed to load QR token", qrError);
+    return NextResponse.json(
+      { error: "Unable to redeem token" },
+      { status: 500 },
+    );
+  }
+
+  if (!qrToken) {
+    return NextResponse.json(
+      { error: "QR token not found" },
+      { status: 404 },
+    );
+  }
+
+  if (qrToken.wallet_id !== walletId) {
+    return NextResponse.json(
+      { error: "QR token does not belong to this wallet" },
+      { status: 403 },
+    );
+  }
+
+  if (qrToken.user_id !== wallet.user_id) {
+    return NextResponse.json(
+      { error: "QR token owner mismatch" },
+      { status: 403 },
+    );
+  }
+
+  if (!qrToken.is_single_use) {
+    return NextResponse.json(
+      { error: "QR token is not redeemable" },
+      { status: 409 },
+    );
+  }
+
+  if (qrToken.redeemed_at) {
+    return NextResponse.json(
+      { error: "QR token already redeemed" },
+      { status: 409 },
+    );
+  }
+
+  const now = new Date();
+  const nowIso = now.toISOString();
+
+  if (qrToken.expires_at && new Date(qrToken.expires_at) <= now) {
+    await transitionWallet({
+      client: supabase,
+      wallet,
+      walletId,
+      nextStatus: "expired",
+      event: {
+        type: "coupon.expired",
+        message: "QR token expired before redemption",
+        at: nowIso,
+        details: {
+          qrTokenId: qrToken.id,
+          expiresAt: qrToken.expires_at,
+        },
+      },
+      mutateMetadata: (metadata) => {
+        const nextMetadata = { ...metadata };
+        const { couponState } = ensureCouponState(nextMetadata);
+
+        if (qrToken.coupon_id) {
+          couponState.couponId = qrToken.coupon_id;
+        }
+
+        const couponCode = extractCouponCodeFromMetadata(qrToken.metadata);
+
+        if (couponCode) {
+          couponState.couponCode = couponCode;
+        }
+
+        couponState.status = "expired";
+        couponState.lastUpdatedAt = nowIso;
+        couponState.qrTokenId = qrToken.id;
+        couponState.qrTokenExpiresAt = qrToken.expires_at;
+
+        nextMetadata.couponState = couponState;
+        return nextMetadata;
+      },
+    });
+
+    return NextResponse.json(
+      { error: "QR token has expired" },
+      { status: 410 },
+    );
+  }
+
+  let coupon:
+    | {
+        id: string;
+        code: string;
+        redeemed_count: number;
+        max_redemptions: number | null;
+        is_active: boolean;
+        end_at: string | null;
+      }
+    | null = null;
+
+  if (qrToken.coupon_id) {
+    const { data, error } = await supabase
+      .from("coupons")
+      .select("id, code, redeemed_count, max_redemptions, is_active, end_at")
+      .eq("id", qrToken.coupon_id)
+      .maybeSingle();
+
+    if (error) {
+      console.error("Failed to load coupon for redemption", error);
+      return NextResponse.json(
+        { error: "Unable to redeem coupon" },
+        { status: 500 },
+      );
+    }
+
+    if (!data) {
+      return NextResponse.json(
+        { error: "Coupon not found" },
+        { status: 404 },
+      );
+    }
+
+    coupon = data;
+
+    if (!coupon.is_active) {
+      return NextResponse.json(
+        { error: "Coupon is no longer active" },
+        { status: 409 },
+      );
+    }
+
+    if (coupon.end_at && new Date(coupon.end_at) < now) {
+      return NextResponse.json(
+        { error: "Coupon has expired" },
+        { status: 409 },
+      );
+    }
+
+    if (
+      coupon.max_redemptions !== null &&
+      coupon.redeemed_count >= coupon.max_redemptions
+    ) {
+      return NextResponse.json(
+        { error: "Coupon redemption limit reached" },
+        { status: 409 },
+      );
+    }
+  }
+
+  const { data: redeemedToken, error: redeemError } = await supabase
+    .from("qr_tokens")
+    .update({ redeemed_at: nowIso })
+    .eq("id", qrToken.id)
+    .eq("wallet_id", walletId)
+    .eq("is_single_use", true)
+    .is("redeemed_at", null)
+    .gt("expires_at", nowIso)
+    .select("id, coupon_id")
+    .maybeSingle();
+
+  if (redeemError) {
+    console.error("Failed to redeem QR token", redeemError);
+    return NextResponse.json(
+      { error: "Unable to redeem QR token" },
+      { status: 500 },
+    );
+  }
+
+  if (!redeemedToken) {
+    return NextResponse.json(
+      { error: "QR token redemption conflict" },
+      { status: 409 },
+    );
+  }
+
+  let redemptionRecord: { id: string } | null = null;
+
+  if (qrToken.coupon_id) {
+    const { data, error } = await supabase
+      .from("coupon_redemptions")
+      .insert({
+        coupon_id: qrToken.coupon_id,
+        user_id: qrToken.user_id,
+        wallet_id: qrToken.wallet_id,
+        qr_token_id: qrToken.id,
+        redeemed_at: nowIso,
+        metadata: {
+          source: "wallet.redeem",
+        },
+      })
+      .select("id")
+      .single();
+
+    if (error) {
+      console.error("Failed to record coupon redemption", error);
+      return NextResponse.json(
+        { error: "Unable to record redemption" },
+        { status: 500 },
+      );
+    }
+
+    redemptionRecord = data;
+  }
+
+  if (coupon) {
+    const { error, data } = await supabase
+      .from("coupons")
+      .update({ redeemed_count: coupon.redeemed_count + 1 })
+      .eq("id", coupon.id)
+      .eq("redeemed_count", coupon.redeemed_count)
+      .select("id, redeemed_count")
+      .maybeSingle();
+
+    if (error) {
+      console.error("Failed to increment coupon redemption count", error);
+    } else if (!data) {
+      console.warn("Coupon redemption count update skipped due to concurrent update", {
+        couponId: coupon.id,
+      });
+    }
+  }
+
+  const updatedWallet = await transitionWallet({
+    client: supabase,
+    wallet,
+    walletId,
+    nextStatus: "used",
+    event: {
+      type: "coupon.redeemed",
+      message: coupon
+        ? `Coupon ${coupon.code} redeemed`
+        : "Wallet QR token redeemed",
+      at: nowIso,
+      details: {
+        couponId: coupon?.id ?? null,
+        qrTokenId: qrToken.id,
+        redemptionId: redemptionRecord?.id ?? null,
+      },
+    },
+    mutateMetadata: (metadata) => {
+      const nextMetadata = { ...metadata };
+      const { couponState } = ensureCouponState(nextMetadata);
+
+      if (coupon) {
+        couponState.couponId = coupon.id;
+        couponState.couponCode = coupon.code;
+      } else if (qrToken.coupon_id) {
+        couponState.couponId = qrToken.coupon_id;
+        const couponCode = extractCouponCodeFromMetadata(qrToken.metadata);
+
+        if (couponCode) {
+          couponState.couponCode = couponCode;
+        }
+      }
+
+      couponState.status = "used";
+      couponState.redeemedAt = nowIso;
+      couponState.lastUpdatedAt = nowIso;
+      couponState.qrTokenId = qrToken.id;
+      couponState.qrTokenExpiresAt = null;
+
+      nextMetadata.couponState = couponState;
+      return nextMetadata;
+    },
+  });
+
+  return NextResponse.json({
+    redeemedAt: nowIso,
+    coupon: coupon
+      ? {
+          id: coupon.id,
+          code: coupon.code,
+        }
+      : null,
+    redemptionId: redemptionRecord?.id ?? null,
+    wallet: {
+      id: updatedWallet.id,
+      status: updatedWallet.status,
+      metadata: updatedWallet.metadata,
+    },
+  });
+}

--- a/lib/qr-token.ts
+++ b/lib/qr-token.ts
@@ -1,0 +1,22 @@
+import { createHash, randomBytes } from "node:crypto";
+
+const URL_SAFE_REPLACEMENTS: Record<string, string> = {
+  "+": "-",
+  "/": "_",
+  "=": "",
+};
+
+function toUrlSafeBase64(value: string) {
+  return value.replace(/[+/=]/g, (character) => URL_SAFE_REPLACEMENTS[character] ?? "");
+}
+
+export function generateQrTokenValue(size = 32) {
+  const raw = randomBytes(size).toString("base64");
+  return toUrlSafeBase64(raw);
+}
+
+export function hashQrToken(token: string) {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+export const QR_TOKEN_TTL_SECONDS = 120;

--- a/lib/wallet-service.ts
+++ b/lib/wallet-service.ts
@@ -1,0 +1,130 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+type JsonRecord = {
+  [key: string]: unknown;
+  events?: unknown;
+  couponState?: unknown;
+};
+
+export type WalletStatus = "active" | "claimed" | "used" | "expired";
+
+export type WalletRow = {
+  id: string;
+  user_id: string;
+  status: string;
+  metadata: JsonRecord | null;
+};
+
+export type WalletEvent = {
+  type: string;
+  message: string;
+  at: string;
+  details?: Record<string, unknown>;
+};
+
+export type WalletMetadataMutator = (metadata: JsonRecord) => JsonRecord;
+
+const MAX_STORED_EVENTS = 25;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function cloneMetadata(metadata: unknown): JsonRecord {
+  if (!isRecord(metadata)) {
+    return {};
+  }
+
+  if (typeof structuredClone === "function") {
+    return structuredClone(metadata as JsonRecord);
+  }
+
+  return JSON.parse(JSON.stringify(metadata));
+}
+
+export async function fetchWallet(
+  client: SupabaseClient,
+  walletId: string,
+): Promise<WalletRow | null> {
+  const { data, error } = await client
+    .from("wallets")
+    .select("id, user_id, status, metadata")
+    .eq("id", walletId)
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  return data;
+}
+
+export async function transitionWallet({
+  client,
+  wallet,
+  walletId,
+  nextStatus,
+  event,
+  mutateMetadata,
+  eventLimit = MAX_STORED_EVENTS,
+}: {
+  client: SupabaseClient;
+  wallet?: WalletRow | null;
+  walletId: string;
+  nextStatus: WalletStatus;
+  event: WalletEvent;
+  mutateMetadata?: WalletMetadataMutator;
+  eventLimit?: number;
+}) {
+  const baseWallet = wallet ?? (await fetchWallet(client, walletId));
+
+  if (!baseWallet) {
+    throw new Error(`Wallet ${walletId} not found`);
+  }
+
+  const metadataClone = cloneMetadata(baseWallet.metadata);
+  const mutatedMetadata = mutateMetadata
+    ? mutateMetadata({ ...metadataClone })
+    : { ...metadataClone };
+
+  const existingEvents = Array.isArray(mutatedMetadata.events)
+    ? [...mutatedMetadata.events]
+    : Array.isArray(metadataClone.events)
+      ? [...metadataClone.events]
+      : [];
+
+  const limit = Math.max(1, eventLimit);
+  const nextEvents = [...existingEvents.slice(-(limit - 1)), event];
+
+  mutatedMetadata.events = nextEvents;
+
+  const { data, error } = await client
+    .from("wallets")
+    .update({
+      status: nextStatus,
+      metadata: mutatedMetadata,
+    })
+    .eq("id", baseWallet.id)
+    .select("id, user_id, status, metadata")
+    .single();
+
+  if (error) {
+    throw error;
+  }
+
+  console.info(`[wallet:${walletId}] ${event.message}`, {
+    event,
+    status: nextStatus,
+  });
+
+  return data;
+}
+
+export function ensureCouponState(metadata: JsonRecord) {
+  const couponState = isRecord(metadata.couponState) ? { ...metadata.couponState } : {};
+
+  return {
+    metadata,
+    couponState,
+  };
+}


### PR DESCRIPTION
## Summary
- add coupon listing and claim routes that validate availability and update wallet state with event logs
- implement wallet QR issuance and redemption endpoints with 120-second tokens and atomic redemption safeguards
- introduce shared helpers for QR token generation plus wallet state transitions and logging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c90bfdf9448329aff230c62f26b6f5