### PR TITLE
Add customer and merchant app route groups with role-aware navigation

### DIFF
--- a/app/(customer)/c/_components/customer-coupon-detail.tsx
+++ b/app/(customer)/c/_components/customer-coupon-detail.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import Link from "next/link";
+
+import { StatusBadge } from "@/app/_components/status-badge";
+import { useAvailableCoupons } from "./use-coupons";
+
+export function CustomerCouponDetail({ couponId }: { couponId: string }) {
+  const { data: coupons = [], isLoading, error, refetch, isFetching } = useAvailableCoupons();
+
+  const coupon = coupons.find((item) => item.id === couponId);
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <p className="text-sm uppercase tracking-wide text-slate-500 dark:text-slate-400">Coupon detail</p>
+          <h1 className="text-3xl font-semibold text-slate-900 dark:text-white">
+            {coupon?.name ?? "Coupon not found"}
+          </h1>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">Code: {coupon?.code ?? "-"}</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          className="inline-flex items-center rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white"
+          disabled={isFetching}
+        >
+          {isFetching ? "Refreshing…" : "Refresh"}
+        </button>
+      </header>
+
+      {isLoading ? (
+        <p className="text-sm text-slate-600 dark:text-slate-300">Loading coupon…</p>
+      ) : error ? (
+        <p className="text-sm text-rose-600 dark:text-rose-300">{(error as Error).message}</p>
+      ) : !coupon ? (
+        <p className="text-sm text-slate-600 dark:text-slate-300">
+          The coupon could not be found. It may have expired or the merchant subscription is inactive.
+        </p>
+      ) : (
+        <div className="space-y-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
+          <div className="flex flex-wrap items-center gap-3">
+            <StatusBadge status="active" label="Available" />
+            <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              Discount type: {coupon.discountType}
+            </span>
+          </div>
+          {coupon.description ? (
+            <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-200">{coupon.description}</p>
+          ) : null}
+          <dl className="grid gap-4 text-sm text-slate-600 dark:text-slate-300 sm:grid-cols-2">
+            <div>
+              <dt className="font-medium text-slate-500 dark:text-slate-400">Value</dt>
+              <dd className="mt-1 font-semibold text-slate-900 dark:text-white">{coupon.discountValue}</dd>
+            </div>
+            <div>
+              <dt className="font-medium text-slate-500 dark:text-slate-400">Store</dt>
+              <dd className="mt-1">{coupon.storeId ?? "Not specified"}</dd>
+            </div>
+          </dl>
+          <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200">
+            <p className="font-semibold text-slate-900 dark:text-white">How to redeem</p>
+            <ol className="mt-2 list-decimal space-y-1 pl-4">
+              <li>Claim the coupon into your wallet using the wallet ID {coupon.storeId ? `for store ${coupon.storeId}` : ""}.</li>
+              <li>Generate a QR token from the wallet page when you are ready to redeem.</li>
+              <li>Present the QR token to the merchant within 120 seconds for scanning.</li>
+            </ol>
+            <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">
+              Need to manage your wallet? Visit the <Link href="/c/wallet" className="font-semibold underline">wallet</Link> page.
+            </p>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/(customer)/c/_components/customer-home-view.tsx
+++ b/app/(customer)/c/_components/customer-home-view.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import Link from "next/link";
+
+import { useAvailableCoupons } from "./use-coupons";
+
+function formatCurrency(value: number) {
+  return new Intl.NumberFormat("ko-KR", {
+    style: "currency",
+    currency: "KRW",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+export function CustomerHomeView() {
+  const { data: coupons = [], isLoading, error, refetch, isFetching } = useAvailableCoupons();
+
+  const featuredCoupons = coupons.slice(0, 3);
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <p className="text-sm uppercase tracking-wide text-slate-500 dark:text-slate-400">Welcome back</p>
+          <h2 className="text-3xl font-semibold text-slate-900 dark:text-white">Discover new offers nearby</h2>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+            Claim and save coupons to your wallet. Active subscriptions keep redemptions smooth and QR codes fast.
+          </p>
+        </div>
+        <Link
+          href="/c/search"
+          className="inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-700 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
+        >
+          Search coupons
+        </Link>
+      </header>
+
+      <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h3 className="text-xl font-semibold text-slate-900 dark:text-white">Featured coupons</h3>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="inline-flex items-center rounded-md border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white"
+            disabled={isFetching}
+          >
+            {isFetching ? "Refreshing…" : "Refresh"}
+          </button>
+        </div>
+
+        {isLoading ? (
+          <p className="mt-4 text-sm text-slate-600 dark:text-slate-300">Loading coupons…</p>
+        ) : error ? (
+          <p className="mt-4 text-sm text-rose-600 dark:text-rose-300">{(error as Error).message}</p>
+        ) : featuredCoupons.length === 0 ? (
+          <p className="mt-4 text-sm text-slate-600 dark:text-slate-300">No active coupons available right now.</p>
+        ) : (
+          <div className="mt-6 grid gap-4 sm:grid-cols-3">
+            {featuredCoupons.map((coupon) => (
+              <Link
+                key={coupon.id}
+                href={`/c/coupon/${coupon.id}`}
+                className="group flex flex-col rounded-xl border border-slate-200 bg-white p-4 shadow-sm transition hover:-translate-y-1 hover:border-slate-400 hover:shadow-md dark:border-slate-700 dark:bg-slate-900"
+              >
+                <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">{coupon.code}</span>
+                <span className="mt-2 text-lg font-semibold text-slate-900 dark:text-white">
+                  {coupon.name ?? "Untitled coupon"}
+                </span>
+                {coupon.description ? (
+                  <p className="mt-2 line-clamp-3 text-sm text-slate-600 dark:text-slate-300">{coupon.description}</p>
+                ) : null}
+                <div className="mt-4 flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+                  <span className="font-semibold text-slate-900 dark:text-white">{formatCurrency(coupon.discountValue)}</span>
+                  <span>{coupon.discountType}</span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app/(customer)/c/_components/customer-navigation.tsx
+++ b/app/(customer)/c/_components/customer-navigation.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { AppNavigation } from "@/app/_components/app-navigation";
+import { StatusBadge } from "@/app/_components/status-badge";
+import { useAuth } from "@/lib/auth-context";
+import { useRoleNavigation } from "@/lib/navigation-context";
+
+export function CustomerNavigation() {
+  const navigation = useRoleNavigation("customer");
+  const { user } = useAuth();
+
+  const roleBadge =
+    user?.role === "customer" ? <StatusBadge status="customer" label="Customer" /> : null;
+
+  return (
+    <AppNavigation
+      title={navigation.title}
+      subtitle={navigation.subtitle}
+      navLinks={navigation.navLinks}
+      actions={roleBadge}
+    />
+  );
+}

--- a/app/(customer)/c/_components/customer-search-view.tsx
+++ b/app/(customer)/c/_components/customer-search-view.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+
+import { useAvailableCoupons } from "./use-coupons";
+
+export function CustomerSearchView() {
+  const [query, setQuery] = useState("");
+  const { data: coupons = [], isLoading, error } = useAvailableCoupons();
+
+  const normalizedQuery = query.trim().toLowerCase();
+
+  const filteredCoupons = useMemo(() => {
+    if (!normalizedQuery) {
+      return coupons;
+    }
+
+    return coupons.filter((coupon) => {
+      const haystack = [coupon.name, coupon.description, coupon.code]
+        .filter(Boolean)
+        .map((value) => value?.toLowerCase() ?? "")
+        .join(" ");
+      return haystack.includes(normalizedQuery);
+    });
+  }, [coupons, normalizedQuery]);
+
+  return (
+    <section className="space-y-6">
+      <header>
+        <h2 className="text-3xl font-semibold text-slate-900 dark:text-white">Search coupons</h2>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+          Look up active coupons by name, code, or description. Only offers from merchants with an active subscription are
+          surfaced.
+        </p>
+      </header>
+
+      <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
+        <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">Search</label>
+        <input
+          type="search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Enter keyword or coupon code"
+          className="mt-2 w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+        />
+
+        <div className="mt-6 space-y-4">
+          {isLoading ? (
+            <p className="text-sm text-slate-600 dark:text-slate-300">Loading coupons…</p>
+          ) : error ? (
+            <p className="text-sm text-rose-600 dark:text-rose-300">{(error as Error).message}</p>
+          ) : filteredCoupons.length === 0 ? (
+            <p className="text-sm text-slate-600 dark:text-slate-300">
+              {normalizedQuery ? "No coupons match your search." : "No active coupons available right now."}
+            </p>
+          ) : (
+            <ul className="divide-y divide-slate-200 dark:divide-slate-800">
+              {filteredCoupons.map((coupon) => (
+                <li key={coupon.id} className="py-3">
+                  <Link
+                    href={`/c/coupon/${coupon.id}`}
+                    className="flex items-center justify-between gap-4 rounded-lg px-2 py-1 transition hover:bg-slate-100 dark:hover:bg-slate-800/60"
+                  >
+                    <div>
+                      <p className="text-sm font-semibold text-slate-900 dark:text-white">{coupon.name ?? coupon.code}</p>
+                      {coupon.description ? (
+                        <p className="text-xs text-slate-600 dark:text-slate-400">{coupon.description}</p>
+                      ) : null}
+                    </div>
+                    <span className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">{coupon.code}</span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/(customer)/c/_components/customer-wallet-view.tsx
+++ b/app/(customer)/c/_components/customer-wallet-view.tsx
@@ -1,0 +1,397 @@
+"use client";
+
+import { StatusBadge } from "@/app/_components/status-badge";
+import { ApiError, extractSubscriptionStatus, parseJsonResponse } from "@/lib/api-client";
+import { useAuth } from "@/lib/auth-context";
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+
+type ClaimResponse = {
+  message: string;
+  coupon: {
+    id: string;
+    code: string;
+    name: string | null;
+    description: string | null;
+  };
+  wallet: {
+    id: string;
+    status: string;
+  };
+};
+
+type GenerateQrResponse = {
+  token: string;
+  expiresAt: string;
+  wallet: {
+    id: string;
+    status: string;
+  };
+};
+
+type RedeemResponse = {
+  redeemedAt: string;
+  coupon: {
+    id: string;
+    code: string;
+  } | null;
+  redemptionId: string | null;
+  wallet: {
+    id: string;
+    status: string;
+  };
+};
+
+type Feedback = {
+  type: "success" | "error";
+  message: string;
+  subscriptionStatus?: string | null;
+};
+
+function formatExpiry(expiresAt: string) {
+  return new Date(expiresAt).toLocaleString();
+}
+
+export function CustomerWalletView() {
+  const { user } = useAuth();
+
+  const [walletId, setWalletId] = useState(user?.defaultWalletId ?? "");
+  const [couponId, setCouponId] = useState("");
+  const [qrCouponId, setQrCouponId] = useState("");
+  const [qrToken, setQrToken] = useState("");
+
+  const [claimFeedback, setClaimFeedback] = useState<Feedback | null>(null);
+  const [qrFeedback, setQrFeedback] = useState<Feedback | null>(null);
+  const [redeemFeedback, setRedeemFeedback] = useState<Feedback | null>(null);
+
+  const [qrResult, setQrResult] = useState<GenerateQrResponse | null>(null);
+  const [redeemResult, setRedeemResult] = useState<RedeemResponse | null>(null);
+
+  const claimMutation = useMutation<ClaimResponse, ApiError, { userId: string; walletId: string; couponId: string }>({
+    mutationFn: async ({ userId, walletId: wallet, couponId: coupon }) => {
+      const response = await fetch(`/api/coupons/${coupon}/claim`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId, walletId: wallet }),
+      });
+
+      return parseJsonResponse<ClaimResponse>(response);
+    },
+    onSuccess: (data) => {
+      setClaimFeedback({ type: "success", message: data.message });
+    },
+    onError: (error) => {
+      const subscriptionStatus = extractSubscriptionStatus(error.payload);
+      setClaimFeedback({
+        type: "error",
+        message: error.message,
+        subscriptionStatus,
+      });
+    },
+  });
+
+  const qrMutation = useMutation<GenerateQrResponse, ApiError, { userId: string; walletId: string; couponId?: string }>(
+    {
+      mutationFn: async ({ userId, walletId: wallet, couponId: coupon }) => {
+        const response = await fetch(`/api/wallet/${wallet}/qr`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ userId, couponId: coupon ?? null }),
+        });
+
+        return parseJsonResponse<GenerateQrResponse>(response);
+      },
+      onSuccess: (data) => {
+        setQrResult(data);
+        setQrFeedback({
+          type: "success",
+          message: `QR token created and expires at ${formatExpiry(data.expiresAt)}`,
+        });
+      },
+      onError: (error) => {
+        const subscriptionStatus = extractSubscriptionStatus(error.payload);
+        setQrFeedback({ type: "error", message: error.message, subscriptionStatus });
+      },
+    },
+  );
+
+  const redeemMutation = useMutation<
+    RedeemResponse,
+    ApiError,
+    { walletId: string; token: string }
+  >({
+    mutationFn: async ({ walletId: wallet, token }) => {
+      const response = await fetch(`/api/wallet/${wallet}/redeem`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token }),
+      });
+
+      return parseJsonResponse<RedeemResponse>(response);
+    },
+    onSuccess: (data) => {
+      setRedeemResult(data);
+      setRedeemFeedback({
+        type: "success",
+        message: data.coupon
+          ? `Coupon ${data.coupon.code} redeemed at ${new Date(data.redeemedAt).toLocaleString()}`
+          : `QR token redeemed at ${new Date(data.redeemedAt).toLocaleString()}`,
+      });
+    },
+    onError: (error) => {
+      const subscriptionStatus = extractSubscriptionStatus(error.payload);
+      setRedeemFeedback({ type: "error", message: error.message, subscriptionStatus });
+    },
+  });
+
+  const ensureAuthenticated = (action: string) => {
+    if (!user) {
+      return `${action} requires login. Use the login page or a demo account first.`;
+    }
+
+    return null;
+  };
+
+  const handleClaimSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setClaimFeedback(null);
+
+    const authError = ensureAuthenticated("Claiming a coupon");
+    if (authError) {
+      setClaimFeedback({ type: "error", message: authError });
+      return;
+    }
+
+    if (!walletId.trim() || !couponId.trim()) {
+      setClaimFeedback({ type: "error", message: "walletId and couponId are required" });
+      return;
+    }
+
+    claimMutation.mutate({ userId: user!.id, walletId: walletId.trim(), couponId: couponId.trim() });
+  };
+
+  const handleQrSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setQrFeedback(null);
+
+    const authError = ensureAuthenticated("Generating a QR token");
+    if (authError) {
+      setQrFeedback({ type: "error", message: authError });
+      return;
+    }
+
+    if (!walletId.trim()) {
+      setQrFeedback({ type: "error", message: "walletId is required" });
+      return;
+    }
+
+    qrMutation.mutate({
+      userId: user!.id,
+      walletId: walletId.trim(),
+      couponId: qrCouponId.trim() || undefined,
+    });
+  };
+
+  const handleRedeemSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setRedeemFeedback(null);
+
+    if (!walletId.trim() || !qrToken.trim()) {
+      setRedeemFeedback({ type: "error", message: "walletId and QR token are required" });
+      return;
+    }
+
+    redeemMutation.mutate({ walletId: walletId.trim(), token: qrToken.trim() });
+  };
+
+  const renderFeedback = (feedback: Feedback | null) => {
+    if (!feedback) {
+      return null;
+    }
+
+    return (
+      <div
+        className={`rounded-lg border px-3 py-2 text-sm ${
+          feedback.type === "success"
+            ? "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-200"
+            : "border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-200"
+        }`}
+      >
+        <p>{feedback.message}</p>
+        {feedback.subscriptionStatus ? (
+          <p className="mt-2 flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+            Subscription status
+            <StatusBadge status={feedback.subscriptionStatus} />
+          </p>
+        ) : null}
+      </div>
+    );
+  };
+
+  return (
+    <section className="space-y-8">
+      <header>
+        <h2 className="text-3xl font-semibold text-slate-900 dark:text-white">Wallet actions</h2>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+          Manage coupon claims, QR tokens, and redemption events. Merchant subscription status determines access to each
+          feature.
+        </p>
+      </header>
+
+      <div className="space-y-6">
+        <form
+          onSubmit={handleClaimSubmit}
+          className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70"
+        >
+          <div>
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Claim coupon</h3>
+            <p className="text-sm text-slate-600 dark:text-slate-300">
+              Claiming a coupon stores it in the wallet and invalidates any previous QR tokens.
+            </p>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="space-y-1 text-sm">
+              <span className="font-medium text-slate-700 dark:text-slate-300">Wallet ID</span>
+              <input
+                type="text"
+                value={walletId}
+                onChange={(event) => setWalletId(event.target.value)}
+                placeholder="wallet-uuid"
+                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+              />
+            </label>
+            <label className="space-y-1 text-sm">
+              <span className="font-medium text-slate-700 dark:text-slate-300">Coupon ID</span>
+              <input
+                type="text"
+                value={couponId}
+                onChange={(event) => setCouponId(event.target.value)}
+                placeholder="coupon-uuid"
+                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+              />
+            </label>
+          </div>
+          <button
+            type="submit"
+            className="inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
+            disabled={claimMutation.isPending}
+          >
+            {claimMutation.isPending ? "Claiming…" : "Claim coupon"}
+          </button>
+          {renderFeedback(claimFeedback)}
+        </form>
+
+        <form
+          onSubmit={handleQrSubmit}
+          className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70"
+        >
+          <div>
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Generate QR token</h3>
+            <p className="text-sm text-slate-600 dark:text-slate-300">
+              QR tokens expire after 120 seconds. They are single-use and require the wallet owner to be logged in.
+            </p>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="space-y-1 text-sm">
+              <span className="font-medium text-slate-700 dark:text-slate-300">Wallet ID</span>
+              <input
+                type="text"
+                value={walletId}
+                onChange={(event) => setWalletId(event.target.value)}
+                placeholder="wallet-uuid"
+                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+              />
+            </label>
+            <label className="space-y-1 text-sm">
+              <span className="font-medium text-slate-700 dark:text-slate-300">Coupon ID (optional)</span>
+              <input
+                type="text"
+                value={qrCouponId}
+                onChange={(event) => setQrCouponId(event.target.value)}
+                placeholder="coupon-uuid"
+                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+              />
+            </label>
+          </div>
+          <button
+            type="submit"
+            className="inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
+            disabled={qrMutation.isPending}
+          >
+            {qrMutation.isPending ? "Generating…" : "Create QR token"}
+          </button>
+          {qrResult ? (
+            <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200">
+              <p>
+                <span className="font-semibold">Token:</span> {qrResult.token}
+              </p>
+              <p>
+                <span className="font-semibold">Expires at:</span> {formatExpiry(qrResult.expiresAt)}
+              </p>
+            </div>
+          ) : null}
+          {renderFeedback(qrFeedback)}
+        </form>
+
+        <form
+          onSubmit={handleRedeemSubmit}
+          className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70"
+        >
+          <div>
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Redeem QR token</h3>
+            <p className="text-sm text-slate-600 dark:text-slate-300">
+              Merchants scan the QR token to redeem a coupon. Redemption succeeds only for active subscriptions.
+            </p>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="space-y-1 text-sm">
+              <span className="font-medium text-slate-700 dark:text-slate-300">Wallet ID</span>
+              <input
+                type="text"
+                value={walletId}
+                onChange={(event) => setWalletId(event.target.value)}
+                placeholder="wallet-uuid"
+                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+              />
+            </label>
+            <label className="space-y-1 text-sm">
+              <span className="font-medium text-slate-700 dark:text-slate-300">QR token</span>
+              <input
+                type="text"
+                value={qrToken}
+                onChange={(event) => setQrToken(event.target.value)}
+                placeholder="single-use token"
+                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+              />
+            </label>
+          </div>
+          <button
+            type="submit"
+            className="inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
+            disabled={redeemMutation.isPending}
+          >
+            {redeemMutation.isPending ? "Redeeming…" : "Redeem token"}
+          </button>
+          {redeemResult ? (
+            <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200">
+              <p>
+                <span className="font-semibold">Redeemed at:</span> {new Date(redeemResult.redeemedAt).toLocaleString()}
+              </p>
+              {redeemResult.coupon ? (
+                <p>
+                  <span className="font-semibold">Coupon:</span> {redeemResult.coupon.code}
+                </p>
+              ) : null}
+              {redeemResult.redemptionId ? (
+                <p>
+                  <span className="font-semibold">Redemption ID:</span> {redeemResult.redemptionId}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+          {renderFeedback(redeemFeedback)}
+        </form>
+      </div>
+    </section>
+  );
+}

--- a/app/(customer)/c/_components/use-coupons.ts
+++ b/app/(customer)/c/_components/use-coupons.ts
@@ -1,0 +1,36 @@
+import { parseJsonResponse } from "@/lib/api-client";
+import { useQuery } from "@tanstack/react-query";
+
+export type CustomerCoupon = {
+  id: string;
+  code: string;
+  name: string | null;
+  description: string | null;
+  discountType: string;
+  discountValue: number;
+  startAt: string | null;
+  endAt: string | null;
+  metadata: Record<string, unknown> | null;
+  redeemedCount: number;
+  maxRedemptions: number | null;
+  storeId: string | null;
+};
+
+type CouponsResponse = {
+  coupons: CustomerCoupon[];
+};
+
+async function fetchCoupons() {
+  const response = await fetch("/api/coupons", { cache: "no-store" });
+  return parseJsonResponse<CouponsResponse>(response);
+}
+
+export function useAvailableCoupons() {
+  return useQuery<CustomerCoupon[]>({
+    queryKey: ["customer", "coupons"],
+    queryFn: async () => {
+      const payload = await fetchCoupons();
+      return payload?.coupons ?? [];
+    },
+  });
+}

--- a/app/(customer)/c/coupon/[id]/page.tsx
+++ b/app/(customer)/c/coupon/[id]/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+
+import { CustomerCouponDetail } from "../../_components/customer-coupon-detail";
+
+export const metadata: Metadata = {
+  title: "Coupon Detail",
+};
+
+type CouponDetailPageProps = {
+  params: { id: string };
+};
+
+export default function CustomerCouponDetailPage({ params }: CouponDetailPageProps) {
+  return <CustomerCouponDetail couponId={params.id} />;
+}

--- a/app/(customer)/c/home/page.tsx
+++ b/app/(customer)/c/home/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+
+import { CustomerHomeView } from "../_components/customer-home-view";
+
+export const metadata: Metadata = {
+  title: "Customer Home",
+};
+
+export default function CustomerHomePage() {
+  return <CustomerHomeView />;
+}

--- a/app/(customer)/c/layout.tsx
+++ b/app/(customer)/c/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+
+import { CustomerNavigation } from "./_components/customer-navigation";
+
+export default function CustomerLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
+      <CustomerNavigation />
+      <main className="mx-auto w-full max-w-6xl px-4 pb-16 pt-8">{children}</main>
+    </div>
+  );
+}

--- a/app/(customer)/c/page.tsx
+++ b/app/(customer)/c/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function CustomerIndexPage() {
+  redirect("/c/home");
+}

--- a/app/(customer)/c/search/page.tsx
+++ b/app/(customer)/c/search/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+
+import { CustomerSearchView } from "../_components/customer-search-view";
+
+export const metadata: Metadata = {
+  title: "Customer Search",
+};
+
+export default function CustomerSearchPage() {
+  return <CustomerSearchView />;
+}

--- a/app/(customer)/c/wallet/page.tsx
+++ b/app/(customer)/c/wallet/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+
+import { CustomerWalletView } from "../_components/customer-wallet-view";
+
+export const metadata: Metadata = {
+  title: "Customer Wallet",
+};
+
+export default function CustomerWalletPage() {
+  return <CustomerWalletView />;
+}

--- a/app/(merchant)/m/_components/merchant-coupons-view.tsx
+++ b/app/(merchant)/m/_components/merchant-coupons-view.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { StatusBadge } from "@/app/_components/status-badge";
+import { ApiError, extractSubscriptionStatus, parseJsonResponse } from "@/lib/api-client";
+import { useAuth } from "@/lib/auth-context";
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+
+type CouponDraft = {
+  code: string;
+  name: string;
+  description: string;
+  discountType: string;
+  discountValue: number;
+  maxRedemptions?: number | null;
+  startAt?: string | null;
+  endAt?: string | null;
+};
+
+type CreateCouponResponse = {
+  message?: string;
+  couponId?: string;
+};
+
+const DEFAULT_DRAFT: CouponDraft = {
+  code: "",
+  name: "",
+  description: "",
+  discountType: "flat",
+  discountValue: 0,
+  maxRedemptions: null,
+  startAt: null,
+  endAt: null,
+};
+
+function canUseAuthoring(status: string | null | undefined) {
+  return status === "active" || status === "grace";
+}
+
+export function MerchantCouponsView() {
+  const { user } = useAuth();
+  const [draft, setDraft] = useState<CouponDraft>(DEFAULT_DRAFT);
+  const [feedback, setFeedback] = useState<{ type: "success" | "error"; message: string; subscriptionStatus?: string | null } | null>(
+    null,
+  );
+
+  const storeId = user?.storeId ?? "";
+  const subscriptionStatus = user?.storeSubscriptionStatus ?? null;
+  const authoringEnabled = canUseAuthoring(subscriptionStatus);
+
+  const mutation = useMutation<CreateCouponResponse, ApiError, CouponDraft>({
+    mutationFn: async (input) => {
+      const response = await fetch("/api/coupons", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...input,
+          storeId,
+        }),
+      });
+
+      return parseJsonResponse<CreateCouponResponse>(response);
+    },
+    onSuccess: (data) => {
+      setFeedback({
+        type: "success",
+        message: data.message ?? `Coupon draft created${data.couponId ? ` (${data.couponId})` : ""}`,
+      });
+      setDraft(DEFAULT_DRAFT);
+    },
+    onError: (error) => {
+      const status = extractSubscriptionStatus(error.payload);
+      setFeedback({ type: "error", message: error.message, subscriptionStatus: status });
+    },
+  });
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!authoringEnabled) {
+      setFeedback({ type: "error", message: "Coupon authoring is disabled until the subscription is reactivated." });
+      return;
+    }
+
+    if (!storeId) {
+      setFeedback({ type: "error", message: "Store ID is required. Ensure your profile is linked to a store." });
+      return;
+    }
+
+    if (!draft.code.trim() || !draft.name.trim()) {
+      setFeedback({ type: "error", message: "Code and name are required." });
+      return;
+    }
+
+    if (!Number.isFinite(draft.discountValue) || draft.discountValue <= 0) {
+      setFeedback({ type: "error", message: "Enter a valid discount value greater than zero." });
+      return;
+    }
+
+    setFeedback(null);
+    mutation.mutate({
+      ...draft,
+      code: draft.code.trim(),
+      name: draft.name.trim(),
+      description: draft.description.trim(),
+    });
+  };
+
+  const updateDraft = (patch: Partial<CouponDraft>) => {
+    setDraft((prev) => ({ ...prev, ...patch }));
+  };
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-semibold text-slate-900 dark:text-white">Create coupon</h1>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+            Author coupons that pass sales review. Publishing is gated by your subscription status.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <StatusBadge status={subscriptionStatus ?? "inactive"} />
+          <span className="text-xs text-slate-500 dark:text-slate-400">Store ID: {storeId || "Not linked"}</span>
+        </div>
+      </header>
+
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70"
+      >
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="space-y-1 text-sm">
+            <span className="font-medium text-slate-700 dark:text-slate-300">Coupon code</span>
+            <input
+              type="text"
+              value={draft.code}
+              onChange={(event) => updateDraft({ code: event.target.value })}
+              placeholder="SPRING50"
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+              disabled={!authoringEnabled}
+            />
+          </label>
+          <label className="space-y-1 text-sm">
+            <span className="font-medium text-slate-700 dark:text-slate-300">Name</span>
+            <input
+              type="text"
+              value={draft.name}
+              onChange={(event) => updateDraft({ name: event.target.value })}
+              placeholder="Spring Promotion"
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+              disabled={!authoringEnabled}
+            />
+          </label>
+        </div>
+        <label className="space-y-1 text-sm">
+          <span className="font-medium text-slate-700 dark:text-slate-300">Description</span>
+          <textarea
+            value={draft.description}
+            onChange={(event) => updateDraft({ description: event.target.value })}
+            rows={3}
+            placeholder="Details about redemption windows and eligibility"
+            className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+            disabled={!authoringEnabled}
+          />
+        </label>
+        <div className="grid gap-4 sm:grid-cols-3">
+          <label className="space-y-1 text-sm">
+            <span className="font-medium text-slate-700 dark:text-slate-300">Discount type</span>
+            <select
+              value={draft.discountType}
+              onChange={(event) => updateDraft({ discountType: event.target.value })}
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+              disabled={!authoringEnabled}
+            >
+              <option value="flat">Flat amount</option>
+              <option value="percent">Percent</option>
+            </select>
+          </label>
+          <label className="space-y-1 text-sm">
+            <span className="font-medium text-slate-700 dark:text-slate-300">Discount value</span>
+            <input
+              type="number"
+              min={0}
+              value={draft.discountValue}
+              onChange={(event) => updateDraft({ discountValue: Number(event.target.value) })}
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+              disabled={!authoringEnabled}
+            />
+          </label>
+          <label className="space-y-1 text-sm">
+            <span className="font-medium text-slate-700 dark:text-slate-300">Max redemptions</span>
+            <input
+              type="number"
+              min={0}
+              value={draft.maxRedemptions ?? ""}
+              onChange={(event) =>
+                updateDraft({
+                  maxRedemptions: event.target.value === "" ? null : Number(event.target.value),
+                })
+              }
+              placeholder="Unlimited"
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+              disabled={!authoringEnabled}
+            />
+          </label>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="space-y-1 text-sm">
+            <span className="font-medium text-slate-700 dark:text-slate-300">Starts at</span>
+            <input
+              type="datetime-local"
+              value={draft.startAt ?? ""}
+              onChange={(event) => updateDraft({ startAt: event.target.value || null })}
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+              disabled={!authoringEnabled}
+            />
+          </label>
+          <label className="space-y-1 text-sm">
+            <span className="font-medium text-slate-700 dark:text-slate-300">Ends at</span>
+            <input
+              type="datetime-local"
+              value={draft.endAt ?? ""}
+              onChange={(event) => updateDraft({ endAt: event.target.value || null })}
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+              disabled={!authoringEnabled}
+            />
+          </label>
+        </div>
+        <button
+          type="submit"
+          className="inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
+          disabled={!authoringEnabled || mutation.isPending}
+        >
+          {mutation.isPending ? "Saving…" : "Save draft"}
+        </button>
+        {feedback ? (
+          <div
+            className={`rounded-lg border px-3 py-2 text-sm ${
+              feedback.type === "success"
+                ? "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-200"
+                : "border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-200"
+            }`}
+          >
+            <p>{feedback.message}</p>
+            {feedback.subscriptionStatus ? (
+              <p className="mt-2 flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+                Subscription status
+                <StatusBadge status={feedback.subscriptionStatus} />
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+        {!authoringEnabled ? (
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Coupon authoring is read-only until billing is reconnected and the subscription returns to active.
+          </p>
+        ) : null}
+      </form>
+    </section>
+  );
+}

--- a/app/(merchant)/m/_components/merchant-home-view.tsx
+++ b/app/(merchant)/m/_components/merchant-home-view.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import Link from "next/link";
+
+import { StatusBadge } from "@/app/_components/status-badge";
+import { useAuth } from "@/lib/auth-context";
+import { useRoleNavigation } from "@/lib/navigation-context";
+
+function describeStatus(status: string | null | undefined) {
+  switch (status) {
+    case "active":
+      return "Subscription is active. All merchant features are available.";
+    case "grace":
+      return "Payment retry is in progress. Core features remain available during the grace period.";
+    case "canceled":
+      return "Subscription is canceled. Renew billing to restore coupon and scan access.";
+    default:
+      return "No subscription on file. Connect billing to unlock coupon authoring and scanning.";
+  }
+}
+
+export function MerchantHomeView() {
+  const { user } = useAuth();
+  const navigation = useRoleNavigation("merchant");
+
+  const subscriptionStatus = user?.storeSubscriptionStatus ?? null;
+  const storeId = user?.storeId ?? "-";
+  const statusDescription = describeStatus(subscriptionStatus);
+
+  return (
+    <section className="space-y-6">
+      <header>
+        <p className="text-sm uppercase tracking-wide text-slate-500 dark:text-slate-400">Merchant overview</p>
+        <h1 className="text-3xl font-semibold text-slate-900 dark:text-white">{user?.name ?? "Merchant"}</h1>
+        <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">Store ID: {storeId}</p>
+      </header>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
+          <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Subscription</p>
+          <div className="mt-2 flex items-center gap-2">
+            <StatusBadge status={subscriptionStatus ?? "inactive"} />
+          </div>
+          <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{statusDescription}</p>
+          <Link
+            href="/m/subscription"
+            className="mt-4 inline-flex items-center text-xs font-semibold text-slate-900 underline underline-offset-2 dark:text-white"
+          >
+            Manage subscription →
+          </Link>
+        </div>
+        <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
+          <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Coupons</p>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+            Draft, activate, and pause coupons to control customer availability in real time.
+          </p>
+          <Link
+            href="/m/coupons"
+            className="mt-4 inline-flex items-center text-xs font-semibold text-slate-900 underline underline-offset-2 dark:text-white"
+          >
+            Go to coupons →
+          </Link>
+        </div>
+        <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
+          <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Scan mode</p>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+            Use QR scanning to verify wallet ownership and complete redemption securely.
+          </p>
+          <Link
+            href="/m/scan"
+            className="mt-4 inline-flex items-center text-xs font-semibold text-slate-900 underline underline-offset-2 dark:text-white"
+          >
+            Open scan station →
+          </Link>
+        </div>
+      </div>
+
+      <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
+        <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Quick navigation</h2>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+          Jump between merchant workflows. These links mirror the navigation items in the header.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-2">
+          {navigation.navLinks.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="inline-flex items-center rounded-full border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white"
+            >
+              {link.label}
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/(merchant)/m/_components/merchant-navigation.tsx
+++ b/app/(merchant)/m/_components/merchant-navigation.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { AppNavigation } from "@/app/_components/app-navigation";
+import { StatusBadge } from "@/app/_components/status-badge";
+import { useAuth } from "@/lib/auth-context";
+import { useRoleNavigation } from "@/lib/navigation-context";
+
+export function MerchantNavigation() {
+  const navigation = useRoleNavigation("merchant");
+  const { user } = useAuth();
+
+  const actions =
+    user?.role === "merchant" ? (
+      <div className="flex items-center gap-2">
+        <StatusBadge status="merchant" label="Merchant" />
+        {user.storeSubscriptionStatus ? <StatusBadge status={user.storeSubscriptionStatus} /> : null}
+      </div>
+    ) : null;
+
+  return (
+    <AppNavigation
+      title={navigation.title}
+      subtitle={navigation.subtitle}
+      navLinks={navigation.navLinks}
+      actions={actions}
+    />
+  );
+}

--- a/app/(merchant)/m/_components/merchant-scan-view.tsx
+++ b/app/(merchant)/m/_components/merchant-scan-view.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { StatusBadge } from "@/app/_components/status-badge";
+import { ApiError, extractSubscriptionStatus, parseJsonResponse } from "@/lib/api-client";
+import { useAuth } from "@/lib/auth-context";
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+
+type RedeemResponse = {
+  redeemedAt: string;
+  coupon: {
+    id: string;
+    code: string;
+  } | null;
+  redemptionId: string | null;
+};
+
+function isScanEnabled(status: string | null | undefined) {
+  return status === "active" || status === "grace";
+}
+
+export function MerchantScanView() {
+  const { user } = useAuth();
+  const [walletId, setWalletId] = useState("");
+  const [token, setToken] = useState("");
+  const [feedback, setFeedback] = useState<{ type: "success" | "error"; message: string; subscriptionStatus?: string | null } | null>(
+    null,
+  );
+
+  const subscriptionStatus = user?.storeSubscriptionStatus ?? null;
+  const scanAllowed = isScanEnabled(subscriptionStatus);
+
+  const mutation = useMutation<RedeemResponse, ApiError, { walletId: string; token: string }>({
+    mutationFn: async ({ walletId: wallet, token: qrToken }) => {
+      const response = await fetch(`/api/wallet/${wallet}/redeem`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token: qrToken }),
+      });
+
+      return parseJsonResponse<RedeemResponse>(response);
+    },
+    onSuccess: (data) => {
+      setFeedback({
+        type: "success",
+        message: data.coupon
+          ? `Redeemed coupon ${data.coupon.code} at ${new Date(data.redeemedAt).toLocaleString()}`
+          : `Token redeemed at ${new Date(data.redeemedAt).toLocaleString()}`,
+      });
+    },
+    onError: (error) => {
+      setFeedback({
+        type: "error",
+        message: error.message,
+        subscriptionStatus: extractSubscriptionStatus(error.payload),
+      });
+    },
+  });
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!scanAllowed) {
+      setFeedback({ type: "error", message: "Scanning is disabled until the subscription is active." });
+      return;
+    }
+
+    if (!walletId.trim() || !token.trim()) {
+      setFeedback({ type: "error", message: "Wallet ID and QR token are required." });
+      return;
+    }
+
+    setFeedback(null);
+    mutation.mutate({ walletId: walletId.trim(), token: token.trim() });
+  };
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-semibold text-slate-900 dark:text-white">Scan and redeem</h1>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+            Input a wallet ID and QR token to simulate the redemption flow from the merchant device.
+          </p>
+        </div>
+        <StatusBadge status={subscriptionStatus ?? "inactive"} />
+      </header>
+
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70"
+      >
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="space-y-1 text-sm">
+            <span className="font-medium text-slate-700 dark:text-slate-300">Wallet ID</span>
+            <input
+              type="text"
+              value={walletId}
+              onChange={(event) => setWalletId(event.target.value)}
+              placeholder="wallet-uuid"
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+              disabled={!scanAllowed}
+            />
+          </label>
+          <label className="space-y-1 text-sm">
+            <span className="font-medium text-slate-700 dark:text-slate-300">QR token</span>
+            <input
+              type="text"
+              value={token}
+              onChange={(event) => setToken(event.target.value)}
+              placeholder="single-use token"
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+              disabled={!scanAllowed}
+            />
+          </label>
+        </div>
+        <button
+          type="submit"
+          className="inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
+          disabled={!scanAllowed || mutation.isPending}
+        >
+          {mutation.isPending ? "Redeeming…" : "Redeem token"}
+        </button>
+        {feedback ? (
+          <div
+            className={`rounded-lg border px-3 py-2 text-sm ${
+              feedback.type === "success"
+                ? "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-200"
+                : "border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-200"
+            }`}
+          >
+            <p>{feedback.message}</p>
+            {feedback.subscriptionStatus ? (
+              <p className="mt-2 flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+                Subscription status
+                <StatusBadge status={feedback.subscriptionStatus} />
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+        {!scanAllowed ? (
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Scan mode is locked while the subscription is inactive. Renew billing to regain access.
+          </p>
+        ) : null}
+      </form>
+    </section>
+  );
+}

--- a/app/(merchant)/m/_components/merchant-subscription-view.tsx
+++ b/app/(merchant)/m/_components/merchant-subscription-view.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { StatusBadge } from "@/app/_components/status-badge";
+import { ApiError, extractSubscriptionStatus, parseJsonResponse } from "@/lib/api-client";
+import { useAuth } from "@/lib/auth-context";
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+
+type RegisterBillingKeyResponse = {
+  billingKey: string;
+  customerKey: string;
+  profile: {
+    id: string;
+    status: string;
+    updatedAt: string;
+  };
+};
+
+type CreateSubscriptionResponse = {
+  subscription: {
+    id: string;
+    planId: string | null;
+    status: string;
+    currentPeriodStart: string | null;
+    currentPeriodEnd: string | null;
+    graceUntil: string | null;
+  };
+  payment: {
+    orderId: string;
+    status: string;
+    approvedAt: string | null;
+  };
+};
+
+function canManageBilling(status: string | null | undefined) {
+  return status === "active" || status === "grace";
+}
+
+export function MerchantSubscriptionView() {
+  const { user } = useAuth();
+  const [customerKey, setCustomerKey] = useState("");
+  const [authKey, setAuthKey] = useState("");
+  const [planId, setPlanId] = useState("");
+  const [orderName, setOrderName] = useState("Subscription");
+  const [amount, setAmount] = useState<string>("");
+  const [registerFeedback, setRegisterFeedback] = useState<
+    { type: "success" | "error"; message: string; subscriptionStatus?: string | null } | null
+  >(null);
+  const [subscribeFeedback, setSubscribeFeedback] = useState<
+    { type: "success" | "error"; message: string; subscriptionStatus?: string | null } | null
+  >(null);
+
+  const storeId = user?.storeId ?? "";
+  const subscriptionStatus = user?.storeSubscriptionStatus ?? null;
+  const billingEnabled = canManageBilling(subscriptionStatus);
+
+  const registerMutation = useMutation<RegisterBillingKeyResponse, ApiError, { customerKey: string; authKey: string }>(
+    {
+      mutationFn: async ({ customerKey: customer, authKey: auth }) => {
+        const response = await fetch("/api/billing/keys", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ storeId, customerKey: customer, authKey: auth }),
+        });
+
+        return parseJsonResponse<RegisterBillingKeyResponse>(response);
+      },
+      onSuccess: (data) => {
+        setRegisterFeedback({
+          type: "success",
+          message: `Billing key ${data.billingKey} registered for customer ${data.customerKey}.`,
+        });
+        setCustomerKey("");
+        setAuthKey("");
+      },
+      onError: (error) => {
+        setRegisterFeedback({
+          type: "error",
+          message: error.message,
+          subscriptionStatus: extractSubscriptionStatus(error.payload),
+        });
+      },
+    },
+  );
+
+  const subscriptionMutation = useMutation<
+    CreateSubscriptionResponse,
+    ApiError,
+    { planId: string; orderName?: string; amountOverride?: number | null }
+  >({
+    mutationFn: async ({ planId: plan, orderName: order, amountOverride }) => {
+      const response = await fetch("/api/billing/subscriptions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          storeId,
+          planId: plan,
+          orderName: order,
+          amountOverride,
+        }),
+      });
+
+      return parseJsonResponse<CreateSubscriptionResponse>(response);
+    },
+    onSuccess: (data) => {
+      const nextMessage = `Subscription ${data.subscription.id} set to ${data.subscription.status}. Payment ${data.payment.status}.`;
+      setSubscribeFeedback({ type: "success", message: nextMessage });
+    },
+    onError: (error) => {
+      setSubscribeFeedback({
+        type: "error",
+        message: error.message,
+        subscriptionStatus: extractSubscriptionStatus(error.payload),
+      });
+    },
+  });
+
+  const handleRegister = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!billingEnabled) {
+      setRegisterFeedback({ type: "error", message: "Billing updates require an active or grace subscription." });
+      return;
+    }
+
+    if (!storeId) {
+      setRegisterFeedback({ type: "error", message: "Store ID is required." });
+      return;
+    }
+
+    if (!customerKey.trim() || !authKey.trim()) {
+      setRegisterFeedback({ type: "error", message: "Customer key and auth key are required." });
+      return;
+    }
+
+    setRegisterFeedback(null);
+    registerMutation.mutate({ customerKey: customerKey.trim(), authKey: authKey.trim() });
+  };
+
+  const handleSubscribe = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!billingEnabled) {
+      setSubscribeFeedback({ type: "error", message: "Activate billing to manage subscriptions." });
+      return;
+    }
+
+    if (!storeId) {
+      setSubscribeFeedback({ type: "error", message: "Store ID is required." });
+      return;
+    }
+
+    if (!planId.trim()) {
+      setSubscribeFeedback({ type: "error", message: "Plan ID is required." });
+      return;
+    }
+
+    const overrideAmount = amount.trim() ? Number(amount) : null;
+
+    setSubscribeFeedback(null);
+    subscriptionMutation.mutate({
+      planId: planId.trim(),
+      orderName: orderName.trim() || undefined,
+      amountOverride: Number.isFinite(overrideAmount ?? NaN) ? overrideAmount : null,
+    });
+  };
+
+  const renderFeedback = (
+    feedback:
+      | {
+          type: "success" | "error";
+          message: string;
+          subscriptionStatus?: string | null;
+        }
+      | null,
+  ) => {
+    if (!feedback) {
+      return null;
+    }
+
+    return (
+      <div
+        className={`rounded-lg border px-3 py-2 text-sm ${
+          feedback.type === "success"
+            ? "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-200"
+            : "border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-200"
+        }`}
+      >
+        <p>{feedback.message}</p>
+        {feedback.subscriptionStatus ? (
+          <p className="mt-2 flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+            Subscription status
+            <StatusBadge status={feedback.subscriptionStatus} />
+          </p>
+        ) : null}
+      </div>
+    );
+  };
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-semibold text-slate-900 dark:text-white">Subscription &amp; billing</h1>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+            Register billing keys and trigger subscription renewals once Toss Payments billing fixes are deployed.
+          </p>
+        </div>
+        <StatusBadge status={subscriptionStatus ?? "inactive"} />
+      </header>
+
+      <form
+        onSubmit={handleRegister}
+        className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70"
+      >
+        <div>
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Register billing key</h2>
+          <p className="text-sm text-slate-600 dark:text-slate-300">
+            Provide the Toss customer key and auth key to vault a billing key for recurring charges.
+          </p>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="space-y-1 text-sm">
+            <span className="font-medium text-slate-700 dark:text-slate-300">Customer key</span>
+            <input
+              type="text"
+              value={customerKey}
+              onChange={(event) => setCustomerKey(event.target.value)}
+              placeholder="cus_Kx..."
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+              disabled={!billingEnabled}
+            />
+          </label>
+          <label className="space-y-1 text-sm">
+            <span className="font-medium text-slate-700 dark:text-slate-300">Auth key</span>
+            <input
+              type="text"
+              value={authKey}
+              onChange={(event) => setAuthKey(event.target.value)}
+              placeholder="billing auth key"
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+              disabled={!billingEnabled}
+            />
+          </label>
+        </div>
+        <button
+          type="submit"
+          className="inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
+          disabled={!billingEnabled || registerMutation.isPending}
+        >
+          {registerMutation.isPending ? "Registering…" : "Register billing key"}
+        </button>
+        {renderFeedback(registerFeedback)}
+        {!billingEnabled ? (
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Billing changes are locked until the subscription is reactivated or payment succeeds.
+          </p>
+        ) : null}
+      </form>
+
+      <form
+        onSubmit={handleSubscribe}
+        className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70"
+      >
+        <div>
+          <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Create subscription charge</h2>
+          <p className="text-sm text-slate-600 dark:text-slate-300">
+            Trigger a billing cycle with the plan identifier. Use amount override for manual retries.
+          </p>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="space-y-1 text-sm">
+            <span className="font-medium text-slate-700 dark:text-slate-300">Plan ID</span>
+            <input
+              type="text"
+              value={planId}
+              onChange={(event) => setPlanId(event.target.value)}
+              placeholder="plan_monthly_001"
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+              disabled={!billingEnabled}
+            />
+          </label>
+          <label className="space-y-1 text-sm">
+            <span className="font-medium text-slate-700 dark:text-slate-300">Order name</span>
+            <input
+              type="text"
+              value={orderName}
+              onChange={(event) => setOrderName(event.target.value)}
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+              disabled={!billingEnabled}
+            />
+          </label>
+        </div>
+        <label className="space-y-1 text-sm">
+          <span className="font-medium text-slate-700 dark:text-slate-300">Amount override (KRW)</span>
+          <input
+            type="number"
+            min={0}
+            value={amount}
+            onChange={(event) => setAmount(event.target.value)}
+            placeholder="Leave blank to use plan price"
+            className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+            disabled={!billingEnabled}
+          />
+        </label>
+        <button
+          type="submit"
+          className="inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
+          disabled={!billingEnabled || subscriptionMutation.isPending}
+        >
+          {subscriptionMutation.isPending ? "Charging…" : "Create subscription charge"}
+        </button>
+        {renderFeedback(subscribeFeedback)}
+      </form>
+    </section>
+  );
+}

--- a/app/(merchant)/m/coupons/page.tsx
+++ b/app/(merchant)/m/coupons/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+
+import { MerchantCouponsView } from "../_components/merchant-coupons-view";
+
+export const metadata: Metadata = {
+  title: "Merchant Coupons",
+};
+
+export default function MerchantCouponsPage() {
+  return <MerchantCouponsView />;
+}

--- a/app/(merchant)/m/home/page.tsx
+++ b/app/(merchant)/m/home/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+
+import { MerchantHomeView } from "../_components/merchant-home-view";
+
+export const metadata: Metadata = {
+  title: "Merchant Home",
+};
+
+export default function MerchantHomePage() {
+  return <MerchantHomeView />;
+}

--- a/app/(merchant)/m/layout.tsx
+++ b/app/(merchant)/m/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+
+import { MerchantNavigation } from "./_components/merchant-navigation";
+
+export default function MerchantLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
+      <MerchantNavigation />
+      <main className="mx-auto w-full max-w-6xl px-4 pb-16 pt-8">{children}</main>
+    </div>
+  );
+}

--- a/app/(merchant)/m/page.tsx
+++ b/app/(merchant)/m/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function MerchantIndexPage() {
+  redirect("/m/home");
+}

--- a/app/(merchant)/m/scan/page.tsx
+++ b/app/(merchant)/m/scan/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+
+import { MerchantScanView } from "../_components/merchant-scan-view";
+
+export const metadata: Metadata = {
+  title: "Merchant Scan",
+};
+
+export default function MerchantScanPage() {
+  return <MerchantScanView />;
+}

--- a/app/(merchant)/m/subscription/page.tsx
+++ b/app/(merchant)/m/subscription/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+
+import { MerchantSubscriptionView } from "../_components/merchant-subscription-view";
+
+export const metadata: Metadata = {
+  title: "Merchant Subscription",
+};
+
+export default function MerchantSubscriptionPage() {
+  return <MerchantSubscriptionView />;
+}

--- a/app/_components/app-navigation.tsx
+++ b/app/_components/app-navigation.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { ReactNode } from "react";
+
+export type AppNavLink = {
+  href: string;
+  label: string;
+};
+
+function buildLinkClasses(isActive: boolean) {
+  const base = "inline-flex items-center rounded-md px-3 py-2 text-sm font-medium transition-colors";
+
+  if (isActive) {
+    return `${base} bg-slate-900 text-white shadow-sm dark:bg-slate-100 dark:text-slate-900`;
+  }
+
+  return `${base} text-slate-600 hover:bg-slate-200/80 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white`;
+}
+
+export function AppNavigation({
+  title,
+  subtitle,
+  navLinks,
+  actions,
+}: {
+  title: string;
+  subtitle: string;
+  navLinks: AppNavLink[];
+  actions?: ReactNode;
+}) {
+  const pathname = usePathname();
+
+  return (
+    <header className="border-b border-slate-200 bg-white/80 backdrop-blur dark:border-slate-800 dark:bg-slate-900/70">
+      <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center justify-between gap-4 px-4 py-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{subtitle}</p>
+          <h1 className="text-xl font-semibold text-slate-900 dark:text-white">{title}</h1>
+        </div>
+        <nav className="flex flex-wrap items-center gap-2">
+          {navLinks.map((link) => {
+            const isActive = pathname.startsWith(link.href);
+            return (
+              <Link key={link.href} href={link.href} className={buildLinkClasses(isActive)}>
+                {link.label}
+              </Link>
+            );
+          })}
+        </nav>
+        {actions ? <div className="ml-auto flex items-center gap-2">{actions}</div> : null}
+      </div>
+    </header>
+  );
+}

--- a/app/_components/home-dashboard.tsx
+++ b/app/_components/home-dashboard.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import { StatusBadge } from "@/app/_components/status-badge";
 import { useAuth } from "@/lib/auth-context";
+import { useNavigation } from "@/lib/navigation-context";
+import { DEMO_USERS } from "@/lib/demo-users";
 import { useQuery } from "@tanstack/react-query";
 
 const fetchWelcomeMessage = async () => {
@@ -13,12 +16,14 @@ const fetchWelcomeMessage = async () => {
 
 export function HomeDashboard() {
   const { user, login, logout } = useAuth();
+  const { resolveHomePath } = useNavigation();
   const { data, isFetching } = useQuery({
     queryKey: ["welcome-message"],
     queryFn: fetchWelcomeMessage,
   });
 
   const isAuthenticated = Boolean(user);
+  const homePath = resolveHomePath();
 
   return (
     <div className="mx-auto flex w-full max-w-5xl flex-col gap-8">
@@ -65,29 +70,65 @@ export function HomeDashboard() {
           Session data is stored in a React context with optional persistence to <code className="rounded bg-slate-200 px-1 dark:bg-slate-800">localStorage</code>.
         </p>
 
-        <div className="mt-4 flex flex-wrap items-center gap-4 rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-800/70">
-          <div>
+        <div className="mt-4 flex flex-wrap gap-4 rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-800/70">
+          <div className="space-y-1">
             <p className="text-sm text-slate-500 dark:text-slate-400">Current user</p>
             <p className="text-lg font-medium text-slate-900 dark:text-white">
               {isAuthenticated ? user?.name : "Guest"}
             </p>
+            {isAuthenticated ? (
+              <div className="space-y-1 text-sm text-slate-600 dark:text-slate-300">
+                <p>
+                  Role: <span className="font-semibold text-slate-900 dark:text-white">{user?.role}</span>
+                </p>
+                {user?.email ? <p>Email: {user.email}</p> : null}
+                {user?.defaultWalletId ? <p>Default wallet: {user.defaultWalletId}</p> : null}
+                {user?.storeId ? <p>Store: {user.storeId}</p> : null}
+                {user?.storeSubscriptionStatus ? (
+                  <div className="flex items-center gap-2">
+                    <span>Subscription:</span>
+                    <StatusBadge status={user.storeSubscriptionStatus} />
+                  </div>
+                ) : null}
+                <p>
+                  Home route: <code className="rounded bg-slate-200 px-1 dark:bg-slate-900">{homePath}</code>
+                </p>
+              </div>
+            ) : (
+              <p className="text-sm text-slate-600 dark:text-slate-300">Use a demo account to explore role-aware routing.</p>
+            )}
           </div>
-          <div className="flex gap-3">
+          <div className="flex flex-1 flex-col gap-3">
+            <div className="grid gap-2 sm:grid-cols-3">
+              {DEMO_USERS.map((demoUser) => {
+                const isActive = user?.id === demoUser.id;
+                return (
+                  <button
+                    key={demoUser.id}
+                    type="button"
+                    onClick={() => login(demoUser)}
+                    className={`rounded-lg border px-3 py-3 text-left text-sm transition ${
+                      isActive
+                        ? "border-slate-900 bg-slate-900 text-white dark:border-white dark:bg-white dark:text-slate-900"
+                        : "border-slate-200 bg-white text-slate-700 hover:border-slate-400 hover:text-slate-900 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-500"
+                    }`}
+                  >
+                    <p className="font-semibold">{demoUser.name}</p>
+                    <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      {demoUser.role}
+                    </p>
+                    {demoUser.storeSubscriptionStatus ? (
+                      <div className="mt-2">
+                        <StatusBadge status={demoUser.storeSubscriptionStatus} />
+                      </div>
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
             <button
               type="button"
-              className="rounded-full bg-slate-900 px-4 py-2 text-sm font-medium text-white shadow hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
-              onClick={() =>
-                login({
-                  name: "Ada Lovelace",
-                  email: "ada@example.com",
-                })
-              }
-            >
-              {isAuthenticated ? "Switch user" : "Quick login"}
-            </button>
-            <button
-              type="button"
-              className="rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white"
+              className="inline-flex w-max items-center justify-center rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white"
               onClick={logout}
               disabled={!isAuthenticated}
             >

--- a/app/_components/status-badge.tsx
+++ b/app/_components/status-badge.tsx
@@ -1,4 +1,4 @@
-type StatusBadgeProps = {
+export type StatusBadgeProps = {
   status: string;
   label?: string;
 };
@@ -9,13 +9,16 @@ function resolveClasses(status: string) {
   switch (normalized) {
     case "approved":
     case "active":
+    case "success":
       return "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/50 dark:text-emerald-200";
     case "rejected":
     case "inactive":
     case "exhausted":
+    case "canceled":
       return "bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-200";
     case "pending":
     case "grace":
+    case "warning":
       return "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200";
     default:
       return "bg-slate-200 text-slate-700 dark:bg-slate-800 dark:text-slate-200";

--- a/app/home/_components/home-redirect.tsx
+++ b/app/home/_components/home-redirect.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo } from "react";
+
+import { StatusBadge } from "@/app/_components/status-badge";
+import { useAuth } from "@/lib/auth-context";
+import { useNavigation } from "@/lib/navigation-context";
+
+export function HomeRedirect() {
+  const { user } = useAuth();
+  const navigation = useNavigation();
+  const router = useRouter();
+
+  const targetPath = useMemo(() => {
+    if (user?.role) {
+      return navigation.resolveHomePath(user.role);
+    }
+
+    return "/login";
+  }, [navigation, user?.role]);
+
+  useEffect(() => {
+    router.replace(targetPath);
+  }, [router, targetPath]);
+
+  return (
+    <div className="mx-auto max-w-md space-y-4 text-center">
+      <StatusBadge status={user?.role ?? "guest"} label={user ? `Redirecting to ${targetPath}` : "Guest"} />
+      <p className="text-sm text-slate-600 dark:text-slate-300">
+        {user
+          ? `Detected ${user.role} role. Redirecting you to ${targetPath}.`
+          : "No authenticated user detected. Redirecting to the login screen."}
+      </p>
+      <p className="text-xs text-slate-500 dark:text-slate-400">
+        Having trouble?{" "}
+        <Link href={targetPath} className="font-semibold underline">
+          Continue manually
+        </Link>{" "}
+        or return to the{" "}
+        <Link href="/" className="font-semibold underline">
+          landing page
+        </Link>
+        .
+      </p>
+    </div>
+  );
+}

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+
+import { HomeRedirect } from "./_components/home-redirect";
+
+export const metadata: Metadata = {
+  title: "Role home",
+};
+
+export default function HomeRouterPage() {
+  return (
+    <main className="flex min-h-[calc(100vh-4rem)] items-center justify-center bg-gradient-to-br from-slate-100 via-white to-slate-200 px-4 py-16 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950">
+      <HomeRedirect />
+    </main>
+  );
+}

--- a/app/login/_components/login-view.tsx
+++ b/app/login/_components/login-view.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+
+import { StatusBadge } from "@/app/_components/status-badge";
+import { ApiError, parseJsonResponse } from "@/lib/api-client";
+import { useAuth } from "@/lib/auth-context";
+import { DEMO_USERS } from "@/lib/demo-users";
+import { useNavigation } from "@/lib/navigation-context";
+import { useMutation } from "@tanstack/react-query";
+
+type MagicLinkResponse = {
+  email: string;
+  magicLink: string;
+  expiresIn: number;
+  redirectTo: string | null;
+  userId: string | null;
+};
+
+export function LoginView() {
+  const { user, login, logout } = useAuth();
+  const navigation = useNavigation();
+  const [email, setEmail] = useState("");
+  const [redirectTo, setRedirectTo] = useState("/home");
+  const [feedback, setFeedback] = useState<{ type: "success" | "error"; message: string } | null>(null);
+  const [magicLink, setMagicLink] = useState<MagicLinkResponse | null>(null);
+
+  const mutation = useMutation<MagicLinkResponse, ApiError, { email: string; redirectTo?: string | null }>({
+    mutationFn: async ({ email: targetEmail, redirectTo: redirect }) => {
+      const response = await fetch("/api/auth/magiclink", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: targetEmail, redirectTo: redirect }),
+      });
+
+      return parseJsonResponse<MagicLinkResponse>(response);
+    },
+    onSuccess: (data) => {
+      setMagicLink(data);
+      setFeedback({
+        type: "success",
+        message: `Magic link issued for ${data.email}. Expires in ${data.expiresIn} seconds.`,
+      });
+    },
+    onError: (error) => {
+      setMagicLink(null);
+      setFeedback({ type: "error", message: error.message });
+    },
+  });
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFeedback(null);
+
+    if (!email.trim()) {
+      setFeedback({ type: "error", message: "Email is required" });
+      return;
+    }
+
+    mutation.mutate({ email: email.trim(), redirectTo: redirectTo.trim() || undefined });
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-8">
+      <header className="space-y-2 text-center">
+        <p className="text-sm uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Codex Star DM</p>
+        <h1 className="text-3xl font-semibold text-slate-900 dark:text-white">Sign in or switch role</h1>
+        <p className="text-sm text-slate-600 dark:text-slate-300">
+          Request a passwordless magic link or use a demo persona to explore the role-based navigation flows.
+        </p>
+      </header>
+
+      <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
+        <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Magic link</h2>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+          Enter an email address to generate a development magic link. The backend will deliver the email once transport is
+          configured.
+        </p>
+        <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+          <label className="space-y-1 text-sm">
+            <span className="font-medium text-slate-700 dark:text-slate-300">Email</span>
+            <input
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder="you@example.com"
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+            />
+          </label>
+          <label className="space-y-1 text-sm">
+            <span className="font-medium text-slate-700 dark:text-slate-300">Redirect after login</span>
+            <input
+              type="text"
+              value={redirectTo}
+              onChange={(event) => setRedirectTo(event.target.value)}
+              placeholder="/home"
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+            />
+          </label>
+          <button
+            type="submit"
+            className="inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
+            disabled={mutation.isPending}
+          >
+            {mutation.isPending ? "Sending…" : "Send magic link"}
+          </button>
+        </form>
+        {feedback ? (
+          <div
+            className={`mt-4 rounded-lg border px-3 py-2 text-sm ${
+              feedback.type === "success"
+                ? "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-200"
+                : "border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-200"
+            }`}
+          >
+            <p>{feedback.message}</p>
+            {magicLink ? (
+              <p className="mt-2 break-all text-xs text-slate-500 dark:text-slate-400">
+                {magicLink.magicLink}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+      </section>
+
+      <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
+        <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Demo personas</h2>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+          Quickly authenticate as a customer, merchant, or sales operator. This updates the auth context and triggers the
+          role-based redirect target at <code className="rounded bg-slate-200 px-1 dark:bg-slate-800">/home</code>.
+        </p>
+        <div className="mt-4 grid gap-3 sm:grid-cols-3">
+          {DEMO_USERS.map((demoUser) => {
+            const isActive = user?.id === demoUser.id;
+            return (
+              <button
+                key={demoUser.id}
+                type="button"
+                onClick={() => login(demoUser)}
+                className={`rounded-lg border px-3 py-3 text-left text-sm transition ${
+                  isActive
+                    ? "border-slate-900 bg-slate-900 text-white dark:border-white dark:bg-white dark:text-slate-900"
+                    : "border-slate-200 bg-white text-slate-700 hover:border-slate-400 hover:text-slate-900 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-500"
+                }`}
+              >
+                <p className="font-semibold">{demoUser.name}</p>
+                <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">{demoUser.role}</p>
+                {demoUser.storeSubscriptionStatus ? (
+                  <div className="mt-2">
+                    <StatusBadge status={demoUser.storeSubscriptionStatus} />
+                  </div>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+        <div className="mt-4 flex items-center justify-between">
+          <div className="space-y-1 text-sm text-slate-600 dark:text-slate-300">
+            <p>
+              Current user: <span className="font-semibold text-slate-900 dark:text-white">{user?.name ?? "Guest"}</span>
+            </p>
+            <p>
+              Home redirect: <code className="rounded bg-slate-200 px-1 dark:bg-slate-800">{navigation.resolveHomePath()}</code>
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Link
+              href="/home"
+              className="inline-flex items-center rounded-full border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white"
+            >
+              Go to /home
+            </Link>
+            <button
+              type="button"
+              onClick={logout}
+              className="inline-flex items-center rounded-full border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white"
+              disabled={!user}
+            >
+              Sign out
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+
+import { LoginView } from "./_components/login-view";
+
+export const metadata: Metadata = {
+  title: "Login",
+};
+
+export default function LoginPage() {
+  return (
+    <main className="flex min-h-[calc(100vh-4rem)] items-center justify-center bg-gradient-to-br from-slate-100 via-white to-slate-200 px-4 py-16 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950">
+      <LoginView />
+    </main>
+  );
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -3,6 +3,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState, type ReactNode } from "react";
 import { AuthProvider } from "@/lib/auth-context";
+import { NavigationProvider } from "@/lib/navigation-context";
 
 export function Providers({ children }: { children: ReactNode }) {
   const [queryClient] = useState(
@@ -19,7 +20,9 @@ export function Providers({ children }: { children: ReactNode }) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <AuthProvider>{children}</AuthProvider>
+      <AuthProvider>
+        <NavigationProvider>{children}</NavigationProvider>
+      </AuthProvider>
     </QueryClientProvider>
   );
 }

--- a/app/s/_components/sales-approvals-view.tsx
+++ b/app/s/_components/sales-approvals-view.tsx
@@ -3,7 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState, type FormEvent } from "react";
 
-import { StatusBadge } from "./status-badge";
+import { StatusBadge } from "@/app/_components/status-badge";
 
 type CouponApproval = {
   status: "pending" | "approved" | "rejected" | string;

--- a/app/s/_components/sales-invite-codes-view.tsx
+++ b/app/s/_components/sales-invite-codes-view.tsx
@@ -3,7 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
-import { StatusBadge } from "./status-badge";
+import { StatusBadge } from "@/app/_components/status-badge";
 
 type InviteCode = {
   id: string;

--- a/app/s/_components/sales-navigation.tsx
+++ b/app/s/_components/sales-navigation.tsx
@@ -1,47 +1,16 @@
 "use client";
 
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-
-const NAV_LINKS = [
-  { href: "/s/stores", label: "Stores" },
-  { href: "/s/approvals", label: "Approvals" },
-  { href: "/s/invite-codes", label: "Invite Codes" },
-];
-
-function linkClasses(isActive: boolean) {
-  const base =
-    "inline-flex items-center rounded-md px-3 py-2 text-sm font-medium transition-colors";
-  if (isActive) {
-    return `${base} bg-slate-900 text-white shadow-sm dark:bg-slate-100 dark:text-slate-900`;
-  }
-
-  return `${base} text-slate-600 hover:bg-slate-200/80 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white`;
-}
+import { AppNavigation } from "@/app/_components/app-navigation";
+import { useRoleNavigation } from "@/lib/navigation-context";
 
 export function SalesNavigation() {
-  const pathname = usePathname();
+  const navigation = useRoleNavigation("sales");
 
   return (
-    <header className="border-b border-slate-200 bg-white/80 backdrop-blur dark:border-slate-800 dark:bg-slate-900/70">
-      <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-            Sales Console
-          </p>
-          <h1 className="text-xl font-semibold text-slate-900 dark:text-white">Operations Workspace</h1>
-        </div>
-        <nav className="flex gap-2">
-          {NAV_LINKS.map((link) => {
-            const isActive = pathname.startsWith(link.href);
-            return (
-              <Link key={link.href} href={link.href} className={linkClasses(isActive)}>
-                {link.label}
-              </Link>
-            );
-          })}
-        </nav>
-      </div>
-    </header>
+    <AppNavigation
+      title={navigation.title}
+      subtitle={navigation.subtitle}
+      navLinks={navigation.navLinks}
+    />
   );
 }

--- a/app/s/_components/sales-stores-view.tsx
+++ b/app/s/_components/sales-stores-view.tsx
@@ -3,7 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 
-import { StatusBadge } from "./status-badge";
+import { StatusBadge } from "@/app/_components/status-badge";
 
 type SalesStore = {
   id: string;

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -1,0 +1,55 @@
+export class ApiError extends Error {
+  readonly status: number;
+  readonly payload: unknown;
+
+  constructor(message: string, status: number, payload: unknown) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.payload = payload;
+  }
+}
+
+function extractErrorMessage(payload: unknown, fallback: string) {
+  if (payload && typeof payload === "object" && "error" in payload) {
+    const value = (payload as { error?: unknown }).error;
+    if (typeof value === "string" && value.trim()) {
+      return value;
+    }
+  }
+
+  return fallback;
+}
+
+export async function parseJsonResponse<T>(response: Response) {
+  const rawText = await response.text();
+  let payload: unknown = null;
+
+  if (rawText) {
+    try {
+      payload = JSON.parse(rawText) as unknown;
+    } catch {
+      payload = rawText;
+    }
+  }
+
+  if (!response.ok) {
+    const message = extractErrorMessage(payload, `Request failed with status ${response.status}`);
+    throw new ApiError(message, response.status, payload);
+  }
+
+  return payload as T;
+}
+
+export function isApiError(error: unknown): error is ApiError {
+  return error instanceof ApiError;
+}
+
+export function extractSubscriptionStatus(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const value = (payload as Record<string, unknown>).subscriptionStatus;
+  return typeof value === "string" ? value : null;
+}

--- a/lib/demo-users.ts
+++ b/lib/demo-users.ts
@@ -1,0 +1,25 @@
+import type { AuthUser } from "./auth-context";
+
+export const DEMO_USERS: AuthUser[] = [
+  {
+    id: "customer-001",
+    name: "Eunji Kim",
+    email: "eunji.customer@example.com",
+    role: "customer",
+    defaultWalletId: "wallet-demo-001",
+  },
+  {
+    id: "merchant-001",
+    name: "Mina Choi",
+    email: "mina.merchant@example.com",
+    role: "merchant",
+    storeId: "store-demo-001",
+    storeSubscriptionStatus: "active",
+  },
+  {
+    id: "sales-ops-001",
+    name: "Sales Operator",
+    email: "sales.ops@example.com",
+    role: "sales",
+  },
+];

--- a/lib/navigation-context.tsx
+++ b/lib/navigation-context.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+
+import { useAuth, type AuthUser, type UserRole } from "./auth-context";
+
+export type NavigationLink = {
+  href: string;
+  label: string;
+};
+
+export type RoleNavigationDefinition = {
+  role: UserRole;
+  title: string;
+  subtitle: string;
+  homePath: string;
+  navLinks: NavigationLink[];
+};
+
+const ROLE_NAVIGATION: Record<UserRole, RoleNavigationDefinition> = {
+  customer: {
+    role: "customer",
+    title: "Customer Wallet",
+    subtitle: "Customer App",
+    homePath: "/c/home",
+    navLinks: [
+      { href: "/c/home", label: "Home" },
+      { href: "/c/search", label: "Search" },
+      { href: "/c/wallet", label: "Wallet" },
+    ],
+  },
+  merchant: {
+    role: "merchant",
+    title: "Merchant Console",
+    subtitle: "Merchant Portal",
+    homePath: "/m/home",
+    navLinks: [
+      { href: "/m/home", label: "Home" },
+      { href: "/m/coupons", label: "Coupons" },
+      { href: "/m/scan", label: "Scan" },
+      { href: "/m/subscription", label: "Subscription" },
+    ],
+  },
+  sales: {
+    role: "sales",
+    title: "Operations Workspace",
+    subtitle: "Sales Console",
+    homePath: "/s/stores",
+    navLinks: [
+      { href: "/s/stores", label: "Stores" },
+      { href: "/s/approvals", label: "Approvals" },
+      { href: "/s/invite-codes", label: "Invite Codes" },
+    ],
+  },
+};
+
+const DEFAULT_HOME_PATH = "/";
+const DEFAULT_ROLE: UserRole = "customer";
+
+function resolveActiveRole(user: AuthUser | null): UserRole | null {
+  return user?.role ?? null;
+}
+
+type NavigationContextValue = {
+  activeRole: UserRole | null;
+  definition: RoleNavigationDefinition | null;
+  resolveHomePath: (role?: UserRole | null) => string;
+  getDefinitionForRole: (role: UserRole) => RoleNavigationDefinition;
+};
+
+const NavigationContext = createContext<NavigationContextValue | undefined>(undefined);
+
+export function NavigationProvider({ children }: { children: ReactNode }) {
+  const { user } = useAuth();
+
+  const value = useMemo<NavigationContextValue>(() => {
+    const activeRole = resolveActiveRole(user);
+    const definition = activeRole ? ROLE_NAVIGATION[activeRole] : null;
+
+    const resolveHomePath = (role?: UserRole | null) => {
+      if (role && ROLE_NAVIGATION[role]) {
+        return ROLE_NAVIGATION[role].homePath;
+      }
+
+      if (definition) {
+        return definition.homePath;
+      }
+
+      return DEFAULT_HOME_PATH;
+    };
+
+    const getDefinitionForRole = (role: UserRole) => ROLE_NAVIGATION[role];
+
+    return {
+      activeRole,
+      definition,
+      resolveHomePath,
+      getDefinitionForRole,
+    };
+  }, [user]);
+
+  return <NavigationContext.Provider value={value}>{children}</NavigationContext.Provider>;
+}
+
+export function useNavigation() {
+  const context = useContext(NavigationContext);
+
+  if (!context) {
+    throw new Error("useNavigation must be used within a NavigationProvider");
+  }
+
+  return context;
+}
+
+export function useRoleNavigation(role?: UserRole | null) {
+  const { definition, getDefinitionForRole } = useNavigation();
+
+  if (role) {
+    return getDefinitionForRole(role);
+  }
+
+  if (definition) {
+    return definition;
+  }
+
+  return getDefinitionForRole(DEFAULT_ROLE);
+}


### PR DESCRIPTION
## Summary
- introduce shared navigation primitives and a role-aware navigation context that powers /home redirects
- add customer (/c) and merchant (/m) route groups with coupon browsing, wallet, scan, and billing workflows wired to the existing APIs
- expand the login experience and shared home dashboard to support demo personas and role-scoped navigation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca5ddb21508329bd373416bc8f9aa7