### PR TITLE
Add wallet API route and refactor customer wallet experience

### DIFF
--- a/app/(customer)/c/_components/customer-wallet-view.tsx
+++ b/app/(customer)/c/_components/customer-wallet-view.tsx
@@ -4,7 +4,11 @@ import { StatusBadge } from "@/app/_components/status-badge";
 import { ApiError, extractSubscriptionStatus, parseJsonResponse } from "@/lib/api-client";
 import { useAuth } from "@/lib/auth-context";
 import { useMutation } from "@tanstack/react-query";
-import { useState } from "react";
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+
+import { useCustomerWallet, type WalletCouponEntry } from "./use-wallet";
+
+const EMPTY_ENTRIES: WalletCouponEntry[] = [];
 
 type ClaimResponse = {
   message: string;
@@ -48,17 +52,111 @@ type Feedback = {
   subscriptionStatus?: string | null;
 };
 
-function formatExpiry(expiresAt: string) {
-  return new Date(expiresAt).toLocaleString();
+function TokenCountdown({ expiresAt }: { expiresAt?: string | null }) {
+  const [remainingSeconds, setRemainingSeconds] = useState<number | null>(() => {
+    if (!expiresAt) {
+      return null;
+    }
+
+    const target = new Date(expiresAt);
+    if (Number.isNaN(target.getTime())) {
+      return null;
+    }
+
+    const diff = Math.ceil((target.getTime() - Date.now()) / 1000);
+    return diff > 0 ? diff : 0;
+  });
+
+  useEffect(() => {
+    if (!expiresAt) {
+      setRemainingSeconds(null);
+      return;
+    }
+
+    const target = new Date(expiresAt);
+    if (Number.isNaN(target.getTime())) {
+      setRemainingSeconds(null);
+      return;
+    }
+
+    const targetMs = target.getTime();
+
+    const update = () => {
+      const diff = Math.ceil((targetMs - Date.now()) / 1000);
+      setRemainingSeconds(diff > 0 ? diff : 0);
+    };
+
+    update();
+
+    const interval = window.setInterval(update, 1000);
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [expiresAt]);
+
+  if (!expiresAt || remainingSeconds === null) {
+    return <span className="text-slate-500 dark:text-slate-400">—</span>;
+  }
+
+  if (remainingSeconds <= 0) {
+    return <span className="font-semibold text-rose-600 dark:text-rose-300">Expired</span>;
+  }
+
+  const minutes = Math.floor(remainingSeconds / 60);
+  const seconds = remainingSeconds % 60;
+
+  return (
+    <span className="font-semibold text-slate-900 dark:text-white">
+      {minutes}:{seconds.toString().padStart(2, "0")} remaining
+    </span>
+  );
+}
+
+function formatDateTime(value: string | null) {
+  if (!value) {
+    return "—";
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+
+  return parsed.toLocaleString();
+}
+
+function renderFeedback(feedback: Feedback | null) {
+  if (!feedback) {
+    return null;
+  }
+
+  return (
+    <div
+      className={`rounded-lg border px-3 py-2 text-sm ${
+        feedback.type === "success"
+          ? "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-200"
+          : "border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-200"
+      }`}
+    >
+      <p>{feedback.message}</p>
+      {feedback.subscriptionStatus ? (
+        <p className="mt-2 flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+          Subscription status
+          <StatusBadge status={feedback.subscriptionStatus} />
+        </p>
+      ) : null}
+    </div>
+  );
 }
 
 export function CustomerWalletView() {
   const { user } = useAuth();
 
+  const [walletIdInput, setWalletIdInput] = useState(user?.defaultWalletId ?? "");
   const [walletId, setWalletId] = useState(user?.defaultWalletId ?? "");
-  const [couponId, setCouponId] = useState("");
-  const [qrCouponId, setQrCouponId] = useState("");
-  const [qrToken, setQrToken] = useState("");
+  const [claimCouponId, setClaimCouponId] = useState("");
+  const [qrTokenInput, setQrTokenInput] = useState("");
+  const [selectedCouponId, setSelectedCouponId] = useState<string | null>(null);
 
   const [claimFeedback, setClaimFeedback] = useState<Feedback | null>(null);
   const [qrFeedback, setQrFeedback] = useState<Feedback | null>(null);
@@ -66,6 +164,64 @@ export function CustomerWalletView() {
 
   const [qrResult, setQrResult] = useState<GenerateQrResponse | null>(null);
   const [redeemResult, setRedeemResult] = useState<RedeemResponse | null>(null);
+
+  useEffect(() => {
+    if (!walletId && user?.defaultWalletId) {
+      setWalletIdInput(user.defaultWalletId);
+      setWalletId(user.defaultWalletId);
+    }
+  }, [user?.defaultWalletId, walletId]);
+
+  useEffect(() => {
+    setQrResult(null);
+    setRedeemResult(null);
+    setClaimFeedback(null);
+    setQrFeedback(null);
+    setRedeemFeedback(null);
+  }, [walletId]);
+
+  const walletQuery = useCustomerWallet(walletId);
+  const entries = walletQuery.data?.entries ?? EMPTY_ENTRIES;
+
+  useEffect(() => {
+    if (entries.length === 0) {
+      setSelectedCouponId(null);
+      return;
+    }
+
+    setSelectedCouponId((current) => {
+      if (current && entries.some((entry) => entry.couponId === current)) {
+        return current;
+      }
+
+      return entries[0]?.couponId ?? null;
+    });
+  }, [entries]);
+
+  const selectedEntry = useMemo(
+    () => entries.find((entry) => entry.couponId === selectedCouponId) ?? null,
+    [entries, selectedCouponId],
+  );
+
+  const activeQrToken = walletQuery.data?.activeQrToken ?? null;
+  const activeTokenMatchesSelection = Boolean(
+    activeQrToken &&
+      selectedEntry &&
+      activeQrToken.couponId &&
+      activeQrToken.couponId === selectedEntry.couponId,
+  );
+
+  const ensureAuthenticated = (action: string) => {
+    if (!user) {
+      return `${action} requires login. Use the login page or a demo account first.`;
+    }
+
+    if (!walletId.trim()) {
+      return `${action} requires a wallet. Enter a wallet ID and load the wallet first.`;
+    }
+
+    return null;
+  };
 
   const claimMutation = useMutation<ClaimResponse, ApiError, { walletId: string; couponId: string }>({
     mutationFn: async ({ walletId: wallet, couponId: coupon }) => {
@@ -79,6 +235,10 @@ export function CustomerWalletView() {
     },
     onSuccess: (data) => {
       setClaimFeedback({ type: "success", message: data.message });
+      setClaimCouponId("");
+      setSelectedCouponId(data.coupon.id);
+      setQrResult(null);
+      void walletQuery.refetch();
     },
     onError: (error) => {
       const subscriptionStatus = extractSubscriptionStatus(error.payload);
@@ -90,30 +250,29 @@ export function CustomerWalletView() {
     },
   });
 
-  const qrMutation = useMutation<GenerateQrResponse, ApiError, { walletId: string; couponId?: string }>(
-    {
-      mutationFn: async ({ walletId: wallet, couponId: coupon }) => {
-        const response = await fetch(`/api/wallet/${wallet}/qr`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ couponId: coupon ?? null }),
-        });
+  const qrMutation = useMutation<GenerateQrResponse, ApiError, { walletId: string; couponId?: string }>({
+    mutationFn: async ({ walletId: wallet, couponId: coupon }) => {
+      const response = await fetch(`/api/wallet/${wallet}/qr`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ couponId: coupon ?? null }),
+      });
 
-        return parseJsonResponse<GenerateQrResponse>(response);
-      },
-      onSuccess: (data) => {
-        setQrResult(data);
-        setQrFeedback({
-          type: "success",
-          message: `QR token created and expires at ${formatExpiry(data.expiresAt)}`,
-        });
-      },
-      onError: (error) => {
-        const subscriptionStatus = extractSubscriptionStatus(error.payload);
-        setQrFeedback({ type: "error", message: error.message, subscriptionStatus });
-      },
+      return parseJsonResponse<GenerateQrResponse>(response);
     },
-  );
+    onSuccess: (data) => {
+      setQrResult(data);
+      setQrFeedback({
+        type: "success",
+        message: "QR token created. Present it to the merchant before the timer expires.",
+      });
+      void walletQuery.refetch();
+    },
+    onError: (error) => {
+      const subscriptionStatus = extractSubscriptionStatus(error.payload);
+      setQrFeedback({ type: "error", message: error.message, subscriptionStatus });
+    },
+  });
 
   const redeemMutation = useMutation<
     RedeemResponse,
@@ -134,9 +293,11 @@ export function CustomerWalletView() {
       setRedeemFeedback({
         type: "success",
         message: data.coupon
-          ? `Coupon ${data.coupon.code} redeemed at ${new Date(data.redeemedAt).toLocaleString()}`
-          : `QR token redeemed at ${new Date(data.redeemedAt).toLocaleString()}`,
+          ? `Coupon ${data.coupon.code} redeemed at ${formatDateTime(data.redeemedAt)}`
+          : `QR token redeemed at ${formatDateTime(data.redeemedAt)}`,
       });
+      setQrResult(null);
+      void walletQuery.refetch();
     },
     onError: (error) => {
       const subscriptionStatus = extractSubscriptionStatus(error.payload);
@@ -144,15 +305,13 @@ export function CustomerWalletView() {
     },
   });
 
-  const ensureAuthenticated = (action: string) => {
-    if (!user) {
-      return `${action} requires login. Use the login page or a demo account first.`;
-    }
-
-    return null;
+  const handleWalletIdSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = walletIdInput.trim();
+    setWalletId(trimmed);
   };
 
-  const handleClaimSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+  const handleClaimSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setClaimFeedback(null);
 
@@ -162,16 +321,33 @@ export function CustomerWalletView() {
       return;
     }
 
-    if (!walletId.trim() || !couponId.trim()) {
-      setClaimFeedback({ type: "error", message: "walletId and couponId are required" });
+    const coupon = claimCouponId.trim();
+    if (!coupon) {
+      setClaimFeedback({ type: "error", message: "couponId is required" });
       return;
     }
 
-    claimMutation.mutate({ walletId: walletId.trim(), couponId: couponId.trim() });
+    claimMutation.mutate({ walletId: walletId.trim(), couponId: coupon });
   };
 
-  const handleQrSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+  const handleClaimSelected = () => {
+    setClaimFeedback(null);
+
+    const authError = ensureAuthenticated("Claiming a coupon");
+    if (authError) {
+      setClaimFeedback({ type: "error", message: authError });
+      return;
+    }
+
+    if (!selectedEntry?.couponId) {
+      setClaimFeedback({ type: "error", message: "Select a coupon before claiming." });
+      return;
+    }
+
+    claimMutation.mutate({ walletId: walletId.trim(), couponId: selectedEntry.couponId });
+  };
+
+  const handleGenerateQr = () => {
     setQrFeedback(null);
 
     const authError = ensureAuthenticated("Generating a QR token");
@@ -185,46 +361,24 @@ export function CustomerWalletView() {
       return;
     }
 
-    qrMutation.mutate({
-      walletId: walletId.trim(),
-      couponId: qrCouponId.trim() || undefined,
-    });
+    if (!selectedEntry?.couponId) {
+      setQrFeedback({ type: "error", message: "Select a coupon before generating a QR token." });
+      return;
+    }
+
+    qrMutation.mutate({ walletId: walletId.trim(), couponId: selectedEntry.couponId });
   };
 
-  const handleRedeemSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+  const handleRedeemSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setRedeemFeedback(null);
 
-    if (!walletId.trim() || !qrToken.trim()) {
+    if (!walletId.trim() || !qrTokenInput.trim()) {
       setRedeemFeedback({ type: "error", message: "walletId and QR token are required" });
       return;
     }
 
-    redeemMutation.mutate({ walletId: walletId.trim(), token: qrToken.trim() });
-  };
-
-  const renderFeedback = (feedback: Feedback | null) => {
-    if (!feedback) {
-      return null;
-    }
-
-    return (
-      <div
-        className={`rounded-lg border px-3 py-2 text-sm ${
-          feedback.type === "success"
-            ? "border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-200"
-            : "border-rose-200 bg-rose-50 text-rose-700 dark:border-rose-900 dark:bg-rose-950/40 dark:text-rose-200"
-        }`}
-      >
-        <p>{feedback.message}</p>
-        {feedback.subscriptionStatus ? (
-          <p className="mt-2 flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
-            Subscription status
-            <StatusBadge status={feedback.subscriptionStatus} />
-          </p>
-        ) : null}
-      </div>
-    );
+    redeemMutation.mutate({ walletId: walletId.trim(), token: qrTokenInput.trim() });
   };
 
   return (
@@ -232,149 +386,280 @@ export function CustomerWalletView() {
       <header>
         <h2 className="text-3xl font-semibold text-slate-900 dark:text-white">Wallet actions</h2>
         <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
-          Manage coupon claims, QR tokens, and redemption events. Merchant subscription status determines access to each
-          feature.
+          Manage coupon claims, QR tokens, and redemption events. Merchant subscription status determines access to each feature.
         </p>
       </header>
 
       <div className="space-y-6">
-        <form
-          onSubmit={handleClaimSubmit}
-          className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70"
-        >
+        <div className="space-y-6 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
           <div>
-            <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Claim coupon</h3>
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Wallet overview</h3>
             <p className="text-sm text-slate-600 dark:text-slate-300">
-              Claiming a coupon stores it in the wallet and invalidates any previous QR tokens.
+              Load your wallet, claim coupons by ID, and review their current state. Select a coupon from the list to take action.
             </p>
           </div>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <label className="space-y-1 text-sm">
+
+          <form onSubmit={handleWalletIdSubmit} className="flex flex-col gap-3 sm:flex-row">
+            <label className="grow space-y-1 text-sm">
               <span className="font-medium text-slate-700 dark:text-slate-300">Wallet ID</span>
               <input
                 type="text"
-                value={walletId}
-                onChange={(event) => setWalletId(event.target.value)}
+                value={walletIdInput}
+                onChange={(event) => setWalletIdInput(event.target.value)}
                 placeholder="wallet-uuid"
                 className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
               />
             </label>
+            <div className="flex items-end gap-3">
+              <button
+                type="submit"
+                className="inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
+              >
+                Load wallet
+              </button>
+              <button
+                type="button"
+                onClick={() => walletQuery.refetch()}
+                className="inline-flex items-center rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-slate-400 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white"
+                disabled={!walletId.trim() || walletQuery.isFetching}
+              >
+                {walletQuery.isFetching ? "Refreshing…" : "Refresh"}
+              </button>
+            </div>
+          </form>
+
+          {walletQuery.isLoading ? (
+            <p className="text-sm text-slate-600 dark:text-slate-300">Loading wallet…</p>
+          ) : walletQuery.error ? (
+            <p className="text-sm text-rose-600 dark:text-rose-300">{(walletQuery.error as Error).message}</p>
+          ) : walletQuery.data ? (
+            <div className="flex flex-wrap items-center gap-3 text-sm text-slate-600 dark:text-slate-300">
+              <span className="text-slate-500 dark:text-slate-400">Wallet status</span>
+              <StatusBadge status={walletQuery.data.wallet.status} />
+            </div>
+          ) : null}
+
+          <form onSubmit={handleClaimSubmit} className="space-y-3 rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900/50">
+            <div className="text-sm text-slate-600 dark:text-slate-300">
+              <p className="font-medium text-slate-900 dark:text-white">Claim coupon by ID</p>
+              <p>Use this form to add a coupon to your wallet even if it is not listed yet.</p>
+            </div>
             <label className="space-y-1 text-sm">
               <span className="font-medium text-slate-700 dark:text-slate-300">Coupon ID</span>
               <input
                 type="text"
-                value={couponId}
-                onChange={(event) => setCouponId(event.target.value)}
+                value={claimCouponId}
+                onChange={(event) => setClaimCouponId(event.target.value)}
                 placeholder="coupon-uuid"
                 className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
               />
             </label>
-          </div>
-          <button
-            type="submit"
-            className="inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
-            disabled={claimMutation.isPending}
-          >
-            {claimMutation.isPending ? "Claiming…" : "Claim coupon"}
-          </button>
-          {renderFeedback(claimFeedback)}
-        </form>
+            <button
+              type="submit"
+              className="inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
+              disabled={claimMutation.isPending}
+            >
+              {claimMutation.isPending ? "Claiming…" : "Claim coupon"}
+            </button>
+            {renderFeedback(claimFeedback)}
+          </form>
 
-        <form
-          onSubmit={handleQrSubmit}
-          className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70"
-        >
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Wallet coupons
+              </h4>
+              <span className="text-xs text-slate-500 dark:text-slate-400">
+                {entries.length} {entries.length === 1 ? "entry" : "entries"}
+              </span>
+            </div>
+            {entries.length === 0 ? (
+              <p className="text-sm text-slate-600 dark:text-slate-300">
+                No coupons found in this wallet yet. Claim a coupon to get started.
+              </p>
+            ) : (
+              <div className="grid gap-3 md:grid-cols-2">
+                {entries.map((entry) => {
+                  const isSelected = entry.couponId === selectedCouponId;
+                  return (
+                    <button
+                      type="button"
+                      key={entry.couponId}
+                      onClick={() => setSelectedCouponId(entry.couponId)}
+                      className={`w-full rounded-xl border px-4 py-4 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:focus-visible:ring-slate-600 ${
+                        isSelected
+                          ? "border-slate-400 bg-slate-100 shadow-sm dark:border-slate-600 dark:bg-slate-900/60"
+                          : "border-slate-200 hover:border-slate-400 hover:shadow-sm dark:border-slate-800 dark:hover:border-slate-600"
+                      }`}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                            {entry.couponCode ?? entry.couponId}
+                          </p>
+                          <p className="mt-1 text-sm font-medium text-slate-900 dark:text-white">
+                            {entry.couponName ?? "Untitled coupon"}
+                          </p>
+                        </div>
+                        <StatusBadge status={entry.status} />
+                      </div>
+                      <dl className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400">
+                        <div className="flex items-center justify-between gap-2">
+                          <dt>Last update</dt>
+                          <dd>{formatDateTime(entry.lastUpdatedAt)}</dd>
+                        </div>
+                        <div className="flex items-center justify-between gap-2">
+                          <dt>Claimed</dt>
+                          <dd>{formatDateTime(entry.claimedAt)}</dd>
+                        </div>
+                        <div className="flex items-center justify-between gap-2">
+                          <dt>Redeemed</dt>
+                          <dd>{formatDateTime(entry.redeemedAt)}</dd>
+                        </div>
+                      </dl>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
           <div>
-            <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Generate QR token</h3>
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Coupon actions</h3>
             <p className="text-sm text-slate-600 dark:text-slate-300">
-              QR tokens expire after 120 seconds. They are single-use and require the wallet owner to be logged in.
+              Select a coupon to view its details, re-claim it, or generate a fresh QR token. Active tokens expire after 120 seconds.
             </p>
           </div>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <label className="space-y-1 text-sm">
-              <span className="font-medium text-slate-700 dark:text-slate-300">Wallet ID</span>
-              <input
-                type="text"
-                value={walletId}
-                onChange={(event) => setWalletId(event.target.value)}
-                placeholder="wallet-uuid"
-                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
-              />
-            </label>
-            <label className="space-y-1 text-sm">
-              <span className="font-medium text-slate-700 dark:text-slate-300">Coupon ID (optional)</span>
-              <input
-                type="text"
-                value={qrCouponId}
-                onChange={(event) => setQrCouponId(event.target.value)}
-                placeholder="coupon-uuid"
-                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
-              />
-            </label>
-          </div>
-          <button
-            type="submit"
-            className="inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
-            disabled={qrMutation.isPending}
-          >
-            {qrMutation.isPending ? "Generating…" : "Create QR token"}
-          </button>
-          {qrResult ? (
-            <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200">
-              <p>
-                <span className="font-semibold">Token:</span> {qrResult.token}
-              </p>
-              <p>
-                <span className="font-semibold">Expires at:</span> {formatExpiry(qrResult.expiresAt)}
-              </p>
-            </div>
-          ) : null}
-          {renderFeedback(qrFeedback)}
-        </form>
 
-        <form
-          onSubmit={handleRedeemSubmit}
-          className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70"
-        >
+          {selectedEntry ? (
+            <div className="space-y-4">
+              <div className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900/50">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      {selectedEntry.couponCode ?? selectedEntry.couponId}
+                    </p>
+                    <h4 className="mt-1 text-lg font-semibold text-slate-900 dark:text-white">
+                      {selectedEntry.couponName ?? "Untitled coupon"}
+                    </h4>
+                    {selectedEntry.couponDescription ? (
+                      <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+                        {selectedEntry.couponDescription}
+                      </p>
+                    ) : null}
+                  </div>
+                  <StatusBadge status={selectedEntry.status} />
+                </div>
+                <dl className="mt-4 grid gap-2 text-xs text-slate-500 dark:text-slate-400 sm:grid-cols-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <dt>Claimed</dt>
+                    <dd>{formatDateTime(selectedEntry.claimedAt)}</dd>
+                  </div>
+                  <div className="flex items-center justify-between gap-2">
+                    <dt>Last update</dt>
+                    <dd>{formatDateTime(selectedEntry.lastUpdatedAt)}</dd>
+                  </div>
+                  <div className="flex items-center justify-between gap-2">
+                    <dt>Redeemed</dt>
+                    <dd>{formatDateTime(selectedEntry.redeemedAt)}</dd>
+                  </div>
+                </dl>
+                {activeTokenMatchesSelection ? (
+                  <div className="mt-4 rounded-lg border border-slate-200 bg-white/80 px-3 py-2 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-200">
+                    <p className="flex items-center justify-between gap-2">
+                      <span>Active QR token</span>
+                      <TokenCountdown expiresAt={activeQrToken?.expiresAt} />
+                    </p>
+                  </div>
+                ) : null}
+              </div>
+
+              <div className="flex flex-wrap gap-3">
+                <button
+                  type="button"
+                  onClick={handleClaimSelected}
+                  className="inline-flex items-center rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white"
+                  disabled={claimMutation.isPending}
+                >
+                  {claimMutation.isPending ? "Claiming…" : "Claim selected coupon"}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleGenerateQr}
+                  className="inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
+                  disabled={qrMutation.isPending}
+                >
+                  {qrMutation.isPending ? "Generating…" : "Generate QR token"}
+                </button>
+              </div>
+
+              {qrResult ? (
+                <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-900/50 dark:text-slate-200">
+                  <p>
+                    <span className="font-semibold">Token:</span> {qrResult.token}
+                  </p>
+                  <p className="mt-2 flex items-center gap-2">
+                    <span className="font-semibold">Expires in:</span>
+                    <TokenCountdown expiresAt={qrResult.expiresAt} />
+                  </p>
+                  <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                    Expires at {formatDateTime(qrResult.expiresAt)}
+                  </p>
+                </div>
+              ) : null}
+
+              {renderFeedback(qrFeedback)}
+            </div>
+          ) : (
+            <p className="text-sm text-slate-600 dark:text-slate-300">
+              Select a coupon from the wallet list to view details and generate QR tokens.
+            </p>
+          )}
+        </div>
+
+        <div className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900/70">
           <div>
             <h3 className="text-lg font-semibold text-slate-900 dark:text-white">Redeem QR token</h3>
             <p className="text-sm text-slate-600 dark:text-slate-300">
-              Merchants scan the QR token to redeem a coupon. Redemption succeeds only for active subscriptions.
+              Merchants scan the QR token to redeem a coupon. Use this form for manual testing when a merchant device is unavailable.
             </p>
           </div>
-          <div className="grid gap-4 sm:grid-cols-2">
-            <label className="space-y-1 text-sm">
-              <span className="font-medium text-slate-700 dark:text-slate-300">Wallet ID</span>
-              <input
-                type="text"
-                value={walletId}
-                onChange={(event) => setWalletId(event.target.value)}
-                placeholder="wallet-uuid"
-                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
-              />
-            </label>
-            <label className="space-y-1 text-sm">
-              <span className="font-medium text-slate-700 dark:text-slate-300">QR token</span>
-              <input
-                type="text"
-                value={qrToken}
-                onChange={(event) => setQrToken(event.target.value)}
-                placeholder="single-use token"
-                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
-              />
-            </label>
-          </div>
-          <button
-            type="submit"
-            className="inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
-            disabled={redeemMutation.isPending}
-          >
-            {redeemMutation.isPending ? "Redeeming…" : "Redeem token"}
-          </button>
+          <form onSubmit={handleRedeemSubmit} className="space-y-4">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="space-y-1 text-sm">
+                <span className="font-medium text-slate-700 dark:text-slate-300">Wallet ID</span>
+                <input
+                  type="text"
+                  value={walletId}
+                  readOnly
+                  className="w-full rounded-lg border border-slate-300 bg-slate-100 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+                />
+              </label>
+              <label className="space-y-1 text-sm">
+                <span className="font-medium text-slate-700 dark:text-slate-300">QR token</span>
+                <input
+                  type="text"
+                  value={qrTokenInput}
+                  onChange={(event) => setQrTokenInput(event.target.value)}
+                  placeholder="single-use token"
+                  className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
+                />
+              </label>
+            </div>
+            <button
+              type="submit"
+              className="inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
+              disabled={redeemMutation.isPending}
+            >
+              {redeemMutation.isPending ? "Redeeming…" : "Redeem token"}
+            </button>
+          </form>
           {redeemResult ? (
-            <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-200">
+            <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-900/50 dark:text-slate-200">
               <p>
-                <span className="font-semibold">Redeemed at:</span> {new Date(redeemResult.redeemedAt).toLocaleString()}
+                <span className="font-semibold">Redeemed at:</span> {formatDateTime(redeemResult.redeemedAt)}
               </p>
               {redeemResult.coupon ? (
                 <p>
@@ -389,7 +674,7 @@ export function CustomerWalletView() {
             </div>
           ) : null}
           {renderFeedback(redeemFeedback)}
-        </form>
+        </div>
       </div>
     </section>
   );

--- a/app/(customer)/c/_components/use-wallet.ts
+++ b/app/(customer)/c/_components/use-wallet.ts
@@ -1,0 +1,60 @@
+import { parseJsonResponse } from "@/lib/api-client";
+import type { WalletStatus } from "@/lib/wallet-service";
+import { useQuery } from "@tanstack/react-query";
+
+export type WalletCouponEntry = {
+  couponId: string;
+  couponCode: string | null;
+  couponName: string | null;
+  couponDescription: string | null;
+  status: WalletStatus;
+  claimedAt: string | null;
+  redeemedAt: string | null;
+  lastUpdatedAt: string | null;
+  redemptionId: string | null;
+  qrTokenId: string | null;
+  qrTokenExpiresAt: string | null;
+};
+
+export type WalletSummary = {
+  id: string;
+  status: WalletStatus;
+};
+
+export type ActiveQrToken = {
+  id: string;
+  couponId: string | null;
+  couponCode: string | null;
+  expiresAt: string;
+  metadata: Record<string, unknown> | null;
+};
+
+export type CustomerWalletPayload = {
+  wallet: WalletSummary;
+  entries: WalletCouponEntry[];
+  activeQrToken: ActiveQrToken | null;
+};
+
+async function fetchWalletPayload(walletId: string) {
+  const response = await fetch(`/api/wallet/${walletId}`, { cache: "no-store" });
+  return parseJsonResponse<CustomerWalletPayload>(response);
+}
+
+export function useCustomerWallet(walletId?: string | null) {
+  const normalizedId = typeof walletId === "string" ? walletId.trim() : "";
+
+  return useQuery<CustomerWalletPayload>({
+    queryKey: ["customer", "wallet", normalizedId],
+    enabled: Boolean(normalizedId),
+    queryFn: async () => {
+      const payload = await fetchWalletPayload(normalizedId);
+
+      return {
+        wallet: payload.wallet,
+        entries: Array.isArray(payload.entries) ? payload.entries : [],
+        activeQrToken: payload.activeQrToken ?? null,
+      } satisfies CustomerWalletPayload;
+    },
+  });
+}
+

--- a/app/api/wallet/[walletId]/route.ts
+++ b/app/api/wallet/[walletId]/route.ts
@@ -1,0 +1,314 @@
+import { NextResponse } from "next/server";
+
+import {
+  authorizationErrorResponse,
+  isAuthorizationError,
+  requireAuthenticatedUser,
+} from "@/lib/server-auth";
+import {
+  extractCouponState,
+  fetchWallet,
+  type WalletCouponStateRecord,
+  type WalletStatus,
+} from "@/lib/wallet-service";
+
+type CouponRedemptionRow = {
+  id: string;
+  coupon_id: string;
+  redeemed_at: string | null;
+};
+
+type CouponRecord = {
+  id: string;
+  code: string | null;
+  name: string | null;
+  description: string | null;
+};
+
+type ActiveQrTokenRow = {
+  id: string;
+  coupon_id: string | null;
+  expires_at: string | null;
+  metadata: Record<string, unknown> | null;
+};
+
+type WalletCouponEntryResponse = {
+  couponId: string;
+  couponCode: string | null;
+  couponName: string | null;
+  couponDescription: string | null;
+  status: WalletStatus;
+  claimedAt: string | null;
+  redeemedAt: string | null;
+  lastUpdatedAt: string | null;
+  redemptionId: string | null;
+  qrTokenId: string | null;
+  qrTokenExpiresAt: string | null;
+};
+
+type ActiveQrTokenResponse = {
+  id: string;
+  couponId: string | null;
+  couponCode: string | null;
+  expiresAt: string;
+  metadata: Record<string, unknown> | null;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function coerceIsoTimestamp(value: string | null | undefined) {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return parsed.toISOString();
+}
+
+function resolveStatus(state: WalletCouponStateRecord, fallback: WalletStatus): WalletStatus {
+  return state.status ?? fallback;
+}
+
+function extractCouponCodeFromMetadata(metadata: unknown) {
+  if (!isRecord(metadata)) {
+    return null;
+  }
+
+  const value = metadata.couponCode;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : null;
+  }
+
+  return null;
+}
+
+function sortEntries(entries: WalletCouponEntryResponse[]) {
+  return [...entries].sort((a, b) => {
+    const toComparable = (entry: WalletCouponEntryResponse) => {
+      const source = entry.lastUpdatedAt ?? entry.redeemedAt ?? entry.claimedAt;
+      return source ? new Date(source).getTime() : 0;
+    };
+
+    return toComparable(b) - toComparable(a);
+  });
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { walletId: string } },
+) {
+  const walletId = params.walletId;
+
+  if (!walletId) {
+    return NextResponse.json({ error: "walletId is required" }, { status: 400 });
+  }
+
+  let auth;
+
+  try {
+    auth = await requireAuthenticatedUser({ requiredRole: "customer" });
+  } catch (error) {
+    if (isAuthorizationError(error)) {
+      return authorizationErrorResponse(error);
+    }
+
+    throw error;
+  }
+
+  const { supabase, user } = auth;
+  const userId = user.id;
+
+  let wallet;
+
+  try {
+    wallet = await fetchWallet(supabase, walletId);
+  } catch (error) {
+    console.error("Failed to load wallet", error);
+    return NextResponse.json({ error: "Unable to load wallet" }, { status: 500 });
+  }
+
+  if (!wallet) {
+    return NextResponse.json({ error: "Wallet not found" }, { status: 404 });
+  }
+
+  if (wallet.user_id !== userId) {
+    return NextResponse.json({ error: "Wallet does not belong to user" }, { status: 403 });
+  }
+
+  const couponState = extractCouponState(wallet.metadata);
+  const entriesByCouponId = new Map<string, WalletCouponEntryResponse>();
+  const couponIds = new Set<string>();
+
+  if (couponState.couponId) {
+    couponIds.add(couponState.couponId);
+    entriesByCouponId.set(couponState.couponId, {
+      couponId: couponState.couponId,
+      couponCode: couponState.couponCode,
+      couponName: null,
+      couponDescription: null,
+      status: resolveStatus(couponState, "claimed"),
+      claimedAt: couponState.claimedAt,
+      redeemedAt: couponState.redeemedAt,
+      lastUpdatedAt:
+        couponState.lastUpdatedAt ??
+        couponState.redeemedAt ??
+        couponState.claimedAt ??
+        null,
+      redemptionId: null,
+      qrTokenId: couponState.qrTokenId,
+      qrTokenExpiresAt: couponState.qrTokenExpiresAt,
+    });
+  }
+
+  const { data: redemptions, error: redemptionError } = await supabase
+    .from("coupon_redemptions")
+    .select("id, coupon_id, redeemed_at")
+    .eq("wallet_id", walletId)
+    .order("redeemed_at", { ascending: false });
+
+  if (redemptionError) {
+    console.error("Failed to load wallet coupon redemptions", redemptionError);
+    return NextResponse.json({ error: "Unable to load coupon history" }, { status: 500 });
+  }
+
+  if (Array.isArray(redemptions)) {
+    for (const redemption of redemptions as CouponRedemptionRow[]) {
+      if (!redemption.coupon_id) {
+        continue;
+      }
+
+      couponIds.add(redemption.coupon_id);
+
+      const existing = entriesByCouponId.get(redemption.coupon_id);
+      const redeemedAt = coerceIsoTimestamp(redemption.redeemed_at);
+
+      if (existing) {
+        existing.status = "used";
+        existing.redeemedAt = redeemedAt;
+        existing.lastUpdatedAt = existing.lastUpdatedAt ?? redeemedAt;
+        existing.redemptionId = existing.redemptionId ?? redemption.id;
+        continue;
+      }
+
+      entriesByCouponId.set(redemption.coupon_id, {
+        couponId: redemption.coupon_id,
+        couponCode: null,
+        couponName: null,
+        couponDescription: null,
+        status: "used",
+        claimedAt: null,
+        redeemedAt,
+        lastUpdatedAt: redeemedAt,
+        redemptionId: redemption.id,
+        qrTokenId: null,
+        qrTokenExpiresAt: null,
+      });
+    }
+  }
+
+  const nowIso = new Date().toISOString();
+
+  const { data: activeTokens, error: activeTokenError } = await supabase
+    .from("qr_tokens")
+    .select("id, coupon_id, expires_at, metadata")
+    .eq("wallet_id", walletId)
+    .is("redeemed_at", null)
+    .gt("expires_at", nowIso)
+    .order("expires_at", { ascending: true })
+    .limit(1);
+
+  if (activeTokenError) {
+    console.error("Failed to load active QR tokens", activeTokenError);
+    return NextResponse.json({ error: "Unable to load QR tokens" }, { status: 500 });
+  }
+
+  let activeQrToken: ActiveQrTokenResponse | null = null;
+
+  if (Array.isArray(activeTokens) && activeTokens.length > 0) {
+    const token = activeTokens[0] as ActiveQrTokenRow;
+    const expiresAt = coerceIsoTimestamp(token.expires_at);
+
+    if (expiresAt) {
+      const metadata = isRecord(token.metadata) ? { ...token.metadata } : null;
+      const couponCode = extractCouponCodeFromMetadata(metadata ?? undefined);
+      const couponId = token.coupon_id ?? null;
+
+      if (couponId) {
+        couponIds.add(couponId);
+        const existing = entriesByCouponId.get(couponId);
+
+        if (existing) {
+          existing.qrTokenId = existing.qrTokenId ?? token.id;
+          existing.qrTokenExpiresAt = existing.qrTokenExpiresAt ?? expiresAt;
+          existing.lastUpdatedAt = existing.lastUpdatedAt ?? expiresAt;
+        } else {
+          entriesByCouponId.set(couponId, {
+            couponId,
+            couponCode: couponCode ?? null,
+            couponName: null,
+            couponDescription: null,
+            status: "claimed",
+            claimedAt: null,
+            redeemedAt: null,
+            lastUpdatedAt: expiresAt,
+            redemptionId: null,
+            qrTokenId: token.id,
+            qrTokenExpiresAt: expiresAt,
+          });
+        }
+      }
+
+      activeQrToken = {
+        id: token.id,
+        couponId,
+        couponCode: couponCode ?? null,
+        expiresAt,
+        metadata,
+      } satisfies ActiveQrTokenResponse;
+    }
+  }
+
+  if (couponIds.size > 0) {
+    const { data: coupons, error: couponError } = await supabase
+      .from("coupons")
+      .select("id, code, name, description")
+      .in("id", Array.from(couponIds));
+
+    if (couponError) {
+      console.error("Failed to load coupons for wallet", couponError);
+      return NextResponse.json({ error: "Unable to load coupons" }, { status: 500 });
+    }
+
+    if (Array.isArray(coupons)) {
+      for (const coupon of coupons as CouponRecord[]) {
+        const entry = entriesByCouponId.get(coupon.id);
+        if (!entry) {
+          continue;
+        }
+
+        entry.couponCode = entry.couponCode ?? coupon.code;
+        entry.couponName = coupon.name ?? entry.couponName;
+        entry.couponDescription = coupon.description ?? entry.couponDescription;
+      }
+    }
+  }
+
+  const entries = sortEntries(Array.from(entriesByCouponId.values()));
+
+  return NextResponse.json({
+    wallet: {
+      id: wallet.id,
+      status: wallet.status,
+    },
+    entries,
+    activeQrToken,
+  });
+}
+


### PR DESCRIPTION
## Summary
- add an authenticated wallet GET route that composes coupon entries and active QR token metadata
- extend the wallet service helpers so API consumers can safely extract coupon state metadata
- refactor the customer wallet view to use the new query hook, render coupon lists, and show a live QR countdown

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cae506fde88329b4835f233985927f