### PR TITLE
Fix Next 15 route handler typings and build issues

### DIFF
--- a/app/(customer)/c/coupon/[id]/page.tsx
+++ b/app/(customer)/c/coupon/[id]/page.tsx
@@ -7,9 +7,13 @@ export const metadata: Metadata = {
 };
 
 type CouponDetailPageProps = {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 };
 
-export default function CustomerCouponDetailPage({ params }: CouponDetailPageProps) {
-  return <CustomerCouponDetail couponId={params.id} />;
+export default async function CustomerCouponDetailPage({
+  params,
+}: CouponDetailPageProps) {
+  const { id } = await params;
+
+  return <CustomerCouponDetail couponId={id} />;
 }

--- a/app/api/billing/cancel/route.ts
+++ b/app/api/billing/cancel/route.ts
@@ -14,7 +14,7 @@ import {
 
 const ACCESS_TOKEN_COOKIE_NAME = "sb-access-token";
 
-function extractAccessToken(request: Request) {
+async function extractAccessToken(request: Request) {
   const authHeader = request.headers.get("authorization") ?? request.headers.get("Authorization");
 
   if (authHeader && authHeader.startsWith("Bearer ")) {
@@ -24,7 +24,7 @@ function extractAccessToken(request: Request) {
     }
   }
 
-  const cookieStore = cookies();
+  const cookieStore = await cookies();
   const cookieToken = cookieStore.get(ACCESS_TOKEN_COOKIE_NAME)?.value;
   return cookieToken ?? null;
 }
@@ -89,7 +89,7 @@ async function authenticateMerchant(
   request: Request,
   supabase = getSupabaseAdminClient(),
 ): Promise<AuthenticatedMerchant | { error: NextResponse }> {
-  const accessToken = extractAccessToken(request);
+  const accessToken = await extractAccessToken(request);
 
   if (!accessToken) {
     return {

--- a/app/api/billing/webhook/route.ts
+++ b/app/api/billing/webhook/route.ts
@@ -174,7 +174,7 @@ export async function POST(request: Request) {
 
   const { data: subscription, error: subscriptionError } = await supabase
     .from("store_subscriptions")
-    .select("id, store_id, plan_id, current_period_end")
+    .select("id, store_id, plan_id, current_period_end, grace_until")
     .eq("store_id", storeId)
     .maybeSingle();
 

--- a/app/api/coupons/[id]/claim/route.ts
+++ b/app/api/coupons/[id]/claim/route.ts
@@ -15,9 +15,9 @@ type ClaimRequestBody = {
 
 export async function POST(
   request: Request,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
-  const couponId = params.id;
+  const { id: couponId } = await params;
 
   if (!couponId) {
     return NextResponse.json(

--- a/app/api/sales/approvals/[id]/approve/route.ts
+++ b/app/api/sales/approvals/[id]/approve/route.ts
@@ -12,9 +12,9 @@ type ApproveRequestBody = {
 
 export async function POST(
   request: Request,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
-  const couponId = params.id;
+  const { id: couponId } = await params;
 
   if (!couponId) {
     return NextResponse.json(

--- a/app/api/sales/approvals/[id]/reject/route.ts
+++ b/app/api/sales/approvals/[id]/reject/route.ts
@@ -13,9 +13,9 @@ type RejectRequestBody = {
 
 export async function POST(
   request: Request,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
-  const couponId = params.id;
+  const { id: couponId } = await params;
 
   if (!couponId) {
     return NextResponse.json(

--- a/app/api/sales/stores/route.ts
+++ b/app/api/sales/stores/route.ts
@@ -14,7 +14,7 @@ type StoreRow = {
 };
 
 type SalesAssignmentRow = {
-  store: StoreRow | null;
+  store: StoreRow | StoreRow[] | null;
 };
 
 type UserRow = {
@@ -75,7 +75,7 @@ export async function GET() {
   }
 
   const stores = ((assignmentRows ?? []) as SalesAssignmentRow[])
-    .map((row) => row.store)
+    .map((row) => (Array.isArray(row.store) ? row.store[0] ?? null : row.store))
     .filter((store): store is StoreRow => Boolean(store));
 
   stores.sort((a, b) => (a.created_at < b.created_at ? 1 : -1));

--- a/app/api/stores/route.ts
+++ b/app/api/stores/route.ts
@@ -159,13 +159,14 @@ export async function POST(request: Request) {
     await markInviteCodeUsed(adminSupabase, invite);
   } catch (error) {
     console.error("Failed to mark invite code as used", error);
-    await adminSupabase
+    const { error: deleteError } = await adminSupabase
       .from("stores")
       .delete()
-      .eq("id", store.id)
-      .catch((deleteError) => {
-        console.error("Failed to rollback store creation after invite failure", deleteError);
-      });
+      .eq("id", store.id);
+
+    if (deleteError) {
+      console.error("Failed to rollback store creation after invite failure", deleteError);
+    }
     return NextResponse.json(
       { error: "Invite code could not be redeemed" },
       { status: 409 },

--- a/app/api/wallet/[walletId]/qr/route.ts
+++ b/app/api/wallet/[walletId]/qr/route.ts
@@ -31,9 +31,9 @@ function extractCouponIdFromMetadata(metadata: unknown): string | null {
 
 export async function POST(
   request: Request,
-  { params }: { params: { walletId: string } },
+  { params }: { params: Promise<{ walletId: string }> },
 ) {
-  const walletId = params.walletId;
+  const { walletId } = await params;
 
   if (!walletId) {
     return NextResponse.json(

--- a/app/api/wallet/[walletId]/redeem/route.ts
+++ b/app/api/wallet/[walletId]/redeem/route.ts
@@ -24,9 +24,9 @@ function extractCouponCodeFromMetadata(metadata: unknown) {
 
 export async function POST(
   request: Request,
-  { params }: { params: { walletId: string } },
+  { params }: { params: Promise<{ walletId: string }> },
 ) {
-  const walletId = params.walletId;
+  const { walletId } = await params;
 
   if (!walletId) {
     return NextResponse.json(

--- a/app/api/wallet/[walletId]/route.ts
+++ b/app/api/wallet/[walletId]/route.ts
@@ -102,9 +102,9 @@ function sortEntries(entries: WalletCouponEntryResponse[]) {
 
 export async function GET(
   _request: Request,
-  { params }: { params: { walletId: string } },
+  { params }: { params: Promise<{ walletId: string }> },
 ) {
-  const walletId = params.walletId;
+  const { walletId } = await params;
 
   if (!walletId) {
     return NextResponse.json({ error: "walletId is required" }, { status: 400 });

--- a/app/s/_components/sales-approvals-view.tsx
+++ b/app/s/_components/sales-approvals-view.tsx
@@ -326,20 +326,20 @@ export function SalesApprovalsView() {
                       <button
                         type="button"
                         onClick={() => handleApprove(coupon.id)}
-                        disabled={approveMutation.isLoading && approveMutation.variables === coupon.id}
+                        disabled={approveMutation.isPending && approveMutation.variables === coupon.id}
                         className="inline-flex items-center rounded-md bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-70"
                       >
-                        {approveMutation.isLoading && approveMutation.variables === coupon.id
+                        {approveMutation.isPending && approveMutation.variables === coupon.id
                           ? "Approving…"
                           : "Approve"}
                       </button>
                       <button
                         type="button"
                         onClick={() => handleReject(coupon.id)}
-                        disabled={rejectMutation.isLoading && rejectMutation.variables === coupon.id}
+                        disabled={rejectMutation.isPending && rejectMutation.variables === coupon.id}
                         className="inline-flex items-center rounded-md bg-rose-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-rose-700 disabled:opacity-70"
                       >
-                        {rejectMutation.isLoading && rejectMutation.variables === coupon.id
+                        {rejectMutation.isPending && rejectMutation.variables === coupon.id
                           ? "Processing…"
                           : "Reject"}
                       </button>
@@ -362,10 +362,10 @@ export function SalesApprovalsView() {
                         <div className="flex flex-wrap gap-2">
                           <button
                             type="submit"
-                            disabled={rejectMutation.isLoading}
+                            disabled={rejectMutation.isPending}
                             className="inline-flex items-center rounded-md bg-rose-600 px-3 py-1.5 text-sm font-semibold text-white shadow-sm transition hover:bg-rose-700 disabled:opacity-70"
                           >
-                            {rejectMutation.isLoading ? "Submitting…" : "Submit rejection"}
+                            {rejectMutation.isPending ? "Submitting…" : "Submit rejection"}
                           </button>
                           <button
                             type="button"

--- a/app/s/_components/sales-invite-codes-view.tsx
+++ b/app/s/_components/sales-invite-codes-view.tsx
@@ -184,10 +184,10 @@ export function SalesInviteCodesView() {
         </div>
         <button
           type="submit"
-          disabled={mutation.isLoading}
+          disabled={mutation.isPending}
           className="inline-flex items-center rounded-md bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-700 disabled:opacity-70 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200"
         >
-          {mutation.isLoading ? "Issuing…" : "Issue Invite Code"}
+          {mutation.isPending ? "Issuing…" : "Issue Invite Code"}
         </button>
       </form>
 

--- a/lib/supabase-client.ts
+++ b/lib/supabase-client.ts
@@ -65,10 +65,5 @@ export function createSupabaseRouteHandlerClient() {
   return createRouteHandlerClient({ cookies }, {
     supabaseUrl,
     supabaseKey: supabaseAnonKey,
-    options: {
-      auth: {
-        persistSession: false,
-      },
-    },
   });
 }

--- a/lib/toss-client.ts
+++ b/lib/toss-client.ts
@@ -27,7 +27,7 @@ function getTossConfig() {
   return globalForToss.__tossConfig;
 }
 
-async function tossFetch(path: string, init: RequestInit & { body?: unknown }) {
+async function tossFetch(path: string, init: Omit<RequestInit, "body"> & { body?: unknown }) {
   const { baseUrl, secretKey } = getTossConfig();
   const url = `${baseUrl}${path.startsWith("/") ? path : `/${path}`}`;
 


### PR DESCRIPTION
## Summary
- unwrap Next 15 promised route params in coupon, wallet, and sales approval handlers so dynamic routes type-check again
- await cookie access in auth helpers, guard scan verification against missing coupons, and pass promised params into wallet redemption
- update sales dashboards, Supabase/Toss clients, and billing webhook/store cleanup logic to satisfy new library typings

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb045eead48329a53560b246ad09f9