### PR TITLE
Add CI workflow using GitHub secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - work
+  pull_request:
+
+env:
+  SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+  SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+  SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+  TOSS_SECRET_KEY: ${{ secrets.TOSS_SECRET_KEY }}
+  TOSS_API_BASE_URL: ${{ secrets.TOSS_API_BASE_URL }}
+  RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+  MAGIC_LINK_EMAIL_FROM: ${{ secrets.MAGIC_LINK_EMAIL_FROM }}
+  MAGIC_LINK_EMAIL_SUBJECT: ${{ secrets.MAGIC_LINK_EMAIL_SUBJECT }}
+
+jobs:
+  build-and-test:
+    name: Build and test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm run test --if-present
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary
- add a GitHub Actions CI workflow that runs on pushes and pull requests
- source the Supabase, Toss, and email credentials from repository secrets before running lint, tests, and build

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cb24786510832997a3a76cc5804b76