### PR TITLE
Centralize shared data utilities

### DIFF
--- a/app/admin/events/page.tsx
+++ b/app/admin/events/page.tsx
@@ -1,15 +1,11 @@
 import Link from "next/link";
 
 import { getSupabaseAdminClient } from "@/lib/supabase-client";
+import { formatDateTime, isRecord } from "@/lib/utils/data";
 
 export const dynamic = "force-dynamic";
 
 const MAX_EVENTS = 50;
-
-const dateFormatter = new Intl.DateTimeFormat("en-US", {
-  dateStyle: "medium",
-  timeStyle: "short",
-});
 
 type EventRow = {
   id: string;
@@ -28,20 +24,6 @@ type NormalizedEvent = {
   context: Record<string, unknown>;
   details: Record<string, unknown>;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
-function formatDate(value: string) {
-  const date = new Date(value);
-
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-
-  return dateFormatter.format(date);
-}
 
 function normalizeEvent(row: EventRow): NormalizedEvent {
   const payload = isRecord(row.data) ? row.data : {};
@@ -156,10 +138,10 @@ export default async function AdminEventsPage() {
                         <div className="mt-1 text-xs font-normal text-slate-500 dark:text-slate-400">{event.id}</div>
                       </td>
                       <td className="px-4 py-4 text-sm text-slate-700 dark:text-slate-200">
-                        <div>{formatDate(event.occurredAt)}</div>
+                        <div>{formatDateTime(event.occurredAt)}</div>
                         {event.createdAt !== event.occurredAt ? (
                           <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
-                            Recorded {formatDate(event.createdAt)}
+                            Recorded {formatDateTime(event.createdAt)}
                           </div>
                         ) : null}
                       </td>

--- a/app/api/admin/events/route.ts
+++ b/app/api/admin/events/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { getSupabaseAdminClient } from "@/lib/supabase-client";
+import { isRecord, normalizeIsoTimestamp } from "@/lib/utils/data";
 
 type EventRow = {
   id: string;
@@ -40,16 +41,7 @@ function parseSince(raw: string | null) {
     return null;
   }
 
-  const candidate = new Date(raw);
-  if (Number.isNaN(candidate.getTime())) {
-    return null;
-  }
-
-  return candidate.toISOString();
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+  return normalizeIsoTimestamp(raw) ?? null;
 }
 
 function normalizeEvent(row: EventRow): NormalizedEvent {

--- a/app/api/billing/webhook/route.ts
+++ b/app/api/billing/webhook/route.ts
@@ -6,6 +6,7 @@ import {
   calculatePeriodEnd,
   upsertStoreSubscription,
 } from "@/lib/store-service";
+import { normalizeDate, normalizeString } from "@/lib/utils/data";
 
 type TossWebhookPayload = {
   eventType?: string;
@@ -59,15 +60,6 @@ function safeDate(value: string) {
   return date;
 }
 
-function asTrimmedString(value: unknown) {
-  if (typeof value !== "string") {
-    return null;
-  }
-
-  const trimmed = value.trim();
-  return trimmed ? trimmed : null;
-}
-
 function coerceNumber(value: unknown) {
   if (typeof value === "number" && Number.isFinite(value)) {
     return value;
@@ -84,27 +76,11 @@ function coerceNumber(value: unknown) {
 }
 
 function normalizeCurrency(value: unknown) {
-  const trimmed = asTrimmedString(value);
+  const trimmed = normalizeString(value);
   return trimmed ? trimmed.toUpperCase() : null;
 }
 
-function parseOptionalDate(value: unknown) {
-  if (typeof value !== "string") {
-    return null;
-  }
-
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  const parsed = new Date(trimmed);
-  if (Number.isNaN(parsed.getTime())) {
-    return null;
-  }
-
-  return parsed;
-}
+const parseOptionalDate = (value: unknown) => normalizeDate(value);
 
 export async function POST(request: Request) {
   let payload: TossWebhookPayload;
@@ -379,9 +355,9 @@ export async function POST(request: Request) {
     }
 
     const refundNote =
-      asTrimmedString(eventData.reason) ??
-      asTrimmedString(eventData.cancelReason) ??
-      asTrimmedString(eventData.cancellationReason);
+      normalizeString(eventData.reason) ??
+      normalizeString(eventData.cancelReason) ??
+      normalizeString(eventData.cancellationReason);
 
     const cancellationMetadata: Record<string, unknown> = {
       lastWebhookEvent: eventType,

--- a/app/api/wallet/[walletId]/redeem/route.ts
+++ b/app/api/wallet/[walletId]/redeem/route.ts
@@ -8,19 +8,13 @@ import {
   fetchStoreForCoupon,
 } from "@/lib/store-service";
 import { ensureCouponState, transitionWallet } from "@/lib/wallet-service";
+import { asRecord, normalizeString } from "@/lib/utils/data";
 
 type RedeemRequestBody = {
   token?: string;
 };
 
-function extractCouponCodeFromMetadata(metadata: unknown) {
-  if (!metadata || typeof metadata !== "object") {
-    return null;
-  }
-
-  const candidate = (metadata as Record<string, unknown>).couponCode;
-  return typeof candidate === "string" ? candidate : null;
-}
+const extractCouponCodeFromMetadata = (metadata: unknown) => normalizeString(asRecord(metadata)?.couponCode);
 
 export async function POST(
   request: Request,

--- a/lib/utils/data.ts
+++ b/lib/utils/data.ts
@@ -1,0 +1,113 @@
+export type JsonRecord = Record<string, unknown>;
+
+export function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function asRecord(value: unknown): JsonRecord | null {
+  return isRecord(value) ? (value as JsonRecord) : null;
+}
+
+type NormalizeStringOptions = {
+  convertDate?: boolean;
+  trim?: boolean;
+};
+
+export function normalizeString(
+  value: unknown,
+  { convertDate = false, trim = true }: NormalizeStringOptions = {},
+): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+
+    if (trimmed.length === 0) {
+      return null;
+    }
+
+    return trim ? trimmed : value;
+  }
+
+  if (convertDate && value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.toISOString();
+  }
+
+  return null;
+}
+
+type NormalizeIsoTimestampOptions = {
+  onInvalid?: "null" | "undefined";
+};
+
+export function normalizeIsoTimestamp(
+  value: unknown,
+  { onInvalid = "null" }: NormalizeIsoTimestampOptions = {},
+): string | null | undefined {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    const time = value.getTime();
+    return Number.isNaN(time) ? (onInvalid === "undefined" ? undefined : null) : value.toISOString();
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      return null;
+    }
+
+    const parsed = new Date(trimmed);
+
+    if (Number.isNaN(parsed.getTime())) {
+      return onInvalid === "undefined" ? undefined : null;
+    }
+
+    return parsed.toISOString();
+  }
+
+  return onInvalid === "undefined" ? undefined : null;
+}
+
+export function normalizeDate(value: unknown): Date | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+
+    if (!trimmed) {
+      return null;
+    }
+
+    const parsed = new Date(trimmed);
+
+    if (Number.isNaN(parsed.getTime())) {
+      return null;
+    }
+
+    return parsed;
+  }
+
+  return null;
+}
+
+const defaultDateTimeFormatter = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+export function formatDateTime(
+  value: string | Date,
+  formatter: Intl.DateTimeFormat = defaultDateTimeFormatter,
+): string {
+  const date = value instanceof Date ? value : new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return typeof value === "string" ? value : "";
+  }
+
+  return formatter.format(date);
+}


### PR DESCRIPTION
## Summary
- add `lib/utils/data.ts` to centralize record detection, string normalization, ISO timestamp parsing, and display formatting helpers
- replace duplicated helper implementations across wallet services, admin endpoints, and billing/sales routes with the shared utilities to reduce code size

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cb91a6737c8329bcc688f9c4862653