### PR TITLE
Adjust mobile navigation layout

### DIFF
--- a/app/_components/app-navigation.tsx
+++ b/app/_components/app-navigation.tsx
@@ -34,12 +34,12 @@ export function AppNavigation({
 
   return (
     <header className="border-b border-slate-200 bg-white/80 backdrop-blur dark:border-slate-800 dark:bg-slate-900/70">
-      <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center justify-between gap-4 px-4 py-4">
-        <div>
+      <div className="mx-auto flex w-full max-w-6xl flex-col items-start gap-4 px-4 py-4 md:flex-row md:items-center md:justify-between">
+        <div className="w-full md:w-auto">
           <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">{subtitle}</p>
           <h1 className="text-xl font-semibold text-slate-900 dark:text-white">{title}</h1>
         </div>
-        <nav className="flex flex-wrap items-center gap-2">
+        <nav className="-mx-4 flex w-[calc(100%+2rem)] flex-nowrap items-center gap-2 overflow-x-auto px-4 pb-1 md:mx-0 md:w-auto md:flex-wrap md:overflow-visible md:px-0 md:pb-0">
           {navLinks.map((link) => {
             const isActive = pathname.startsWith(link.href);
             return (
@@ -49,7 +49,11 @@ export function AppNavigation({
             );
           })}
         </nav>
-        {actions ? <div className="ml-auto flex items-center gap-2">{actions}</div> : null}
+        {actions ? (
+          <div className="flex w-full items-center gap-2 md:ml-auto md:w-auto md:justify-end">
+            {actions}
+          </div>
+        ) : null}
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- stack header content vertically on small screens and return to the horizontal layout at the tablet breakpoint
- allow the navigation pills to scroll across the full width on mobile while restoring the wrapped layout on larger viewports
- keep the actions slot full width on small screens while right-aligning it on wider viewports

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce773b26208329ba1195e00c1f75c2