### PR TITLE
Adjust login footer layout for mobile

### DIFF
--- a/app/login/_components/login-view.tsx
+++ b/app/login/_components/login-view.tsx
@@ -155,7 +155,7 @@ export function LoginView() {
             );
           })}
         </div>
-        <div className="mt-4 flex items-center justify-between">
+        <div className="mt-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="space-y-1 text-sm text-slate-600 dark:text-slate-300">
             <p>
               Current user: <span className="font-semibold text-slate-900 dark:text-white">{user?.name ?? "Guest"}</span>
@@ -164,17 +164,17 @@ export function LoginView() {
               Home redirect: <code className="rounded bg-slate-200 px-1 dark:bg-slate-800">{navigation.resolveHomePath()}</code>
             </p>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
             <Link
               href="/home"
-              className="inline-flex items-center rounded-full border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white"
+              className="flex w-full items-center justify-center rounded-full border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white sm:w-auto"
             >
               Go to /home
             </Link>
             <button
               type="button"
               onClick={logout}
-              className="inline-flex items-center rounded-full border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white"
+              className="flex w-full items-center justify-center rounded-full border border-slate-300 px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:border-slate-400 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white sm:w-auto"
               disabled={!user}
             >
               Sign out


### PR DESCRIPTION
## Summary
- stack the login footer content on small screens while keeping the side-by-side layout on larger viewports
- allow the CTA buttons to grow full-width on mobile so they remain visible and easy to tap

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce7ef63ff48329be32bcd21698d312