### PR TITLE
Adjust wallet overview buttons for small screens

### DIFF
--- a/app/(customer)/c/_components/customer-wallet-overview-section.tsx
+++ b/app/(customer)/c/_components/customer-wallet-overview-section.tsx
@@ -75,17 +75,17 @@ export function WalletOverviewSection({
             className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-white dark:focus:border-slate-500 dark:focus:ring-slate-600"
           />
         </label>
-        <div className="flex items-end gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
           <button
             type="submit"
-            className="inline-flex items-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
+            className="flex w-full items-center justify-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200 sm:inline-flex sm:w-auto"
           >
             Load wallet
           </button>
           <button
             type="button"
             onClick={onRefreshWallet}
-            className="inline-flex items-center rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-slate-400 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white"
+            className="flex w-full items-center justify-center rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-slate-400 hover:text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 dark:border-slate-700 dark:text-slate-300 dark:hover:border-slate-500 dark:hover:text-white sm:inline-flex sm:w-auto"
             disabled={refreshDisabled}
           >
             {isFetchingWallet ? "Refreshing…" : "Refresh"}


### PR DESCRIPTION
## Summary
- stack the wallet action buttons vertically on small screens while keeping the horizontal layout for larger breakpoints
- allow each button to expand to full width when stacked and ensure disabled/loading styles remain intact

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce7fc3734883298c997908ced261c7